### PR TITLE
Fix unintended folder structure in Cataloging

### DIFF
--- a/docs/cataloging-sample-data.md
+++ b/docs/cataloging-sample-data.md
@@ -10,7 +10,7 @@ The steps below walks you through the creation of STAC Collection and STAC Item.
 
 
     ```bash
-    wget https://raw.githubusercontent.com/Azure/Azure-Orbital-STAC/main/deploy/sample-data/collection_naip_test.json -P ~/data/collection_naip_test.json
+    wget https://raw.githubusercontent.com/Azure/Azure-Orbital-STAC/main/deploy/sample-data/collection_naip_test.json -P ~/data
     ```
 
     ```bash


### PR DESCRIPTION
Our most recent update to the document included a move of sample data from our storage account where STAC collection Json was hosted to github folder. It introduced an error where in the json for STAC collection is copied to a nested folder. 

So, the jumpbox had the following folder:

~/data/collection_naip_test.json/collection_naip_test.json/collection_naip_test.json

Instead of:

~/data/collection_naip_test.json

This fix will correct that folder structure as the existing folder structure breaks the ingestion of STAC collection to PostgreSQL database.