### PR TITLE
Minor fix with azcopy install

### DIFF
--- a/deploy/bicep/groups/cloud-init-ubuntu.txt
+++ b/deploy/bicep/groups/cloud-init-ubuntu.txt
@@ -7,6 +7,6 @@ runcmd:
   - sudo mkdir -p /tmp/downloadazcopy
   - sudo tar -xf /tmp/downloadazcopy-v10-linux --directory /tmp/downloadazcopy
   - sudo rm -f /usr/bin/azcopy
-  - sudo cp /tmp/downloadazcopy/azcopy_linux_amd64_10.17.0/azcopy /usr/bin/
+  - sh -c "sudo cp /tmp/downloadazcopy/azcopy_linux_amd64_*/azcopy /usr/bin/"
   - sudo chmod 755 /usr/bin/azcopy
   - curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash

--- a/deploy/bicep/groups/cloud-init-ubuntu.txt
+++ b/deploy/bicep/groups/cloud-init-ubuntu.txt
@@ -7,6 +7,6 @@ runcmd:
   - sudo mkdir -p /tmp/downloadazcopy
   - sudo tar -xf /tmp/downloadazcopy-v10-linux --directory /tmp/downloadazcopy
   - sudo rm -f /usr/bin/azcopy
-  - sudo cp /tmp/downloadazcopy/azcopy_linux_amd64_*/azcopy /usr/bin/
+  - sudo cp /tmp/downloadazcopy/azcopy_linux_amd64_10.17.0/azcopy /usr/bin/
   - sudo chmod 755 /usr/bin/azcopy
   - curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash


### PR DESCRIPTION
Replacing the regular expression with actual directory name. I think cloud-init is not honouring the pattern matching that bash supports and as a result azcopy was never installed on the VM. Recently, ran into a similar problem with AOI.