### PR TITLE
Bug fixes based on latest testing.

### DIFF
--- a/deploy/bicep/groups/processing.bicep
+++ b/deploy/bicep/groups/processing.bicep
@@ -391,7 +391,7 @@ module akvPolicyForMI '../modules/akv.policy.bicep' = {
   params: {
     keyVaultName: keyVaultName
     policyOps: 'add'
-    objIdForPolicy: aksManagedIdentity.outputs.uamiClientId
+    objIdForPolicy: aksManagedIdentity.outputs.uamiPrincipalId
     secretPermission: [
       'Get'
       'List'

--- a/deploy/helm/stac-scaler/templates/deployment.yaml
+++ b/deploy/helm/stac-scaler/templates/deployment.yaml
@@ -40,9 +40,9 @@ spec:
               value: "{{ $envValue }}"
             {{- end }}
           ports:
-            {{- toYaml .Values.stacfastapi.ports | nindent 12 }}
+            {{- toYaml .Values.stacfastapi.ports | nindent 10 }}
           resources:
-            {{- toYaml .Values.stacfastapi.resources | nindent 12 }}
+            {{- toYaml .Values.stacfastapi.resources | nindent 10 }}
           volumeMounts:
             - name: secrets-store-inline
               mountPath: "/mnt/secrets-store"

--- a/deploy/helm/stac-scaler/templates/service.yaml
+++ b/deploy/helm/stac-scaler/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: app-stacfastapi
-  namespace: {{ .Values.Namespace }}
+  namespace: {{ .Values.deploymentNamespace }}
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     service.beta.kubernetes.io/azure-dns-label-name: app-stacfastapi-{{ .Values.envCode }}

--- a/deploy/scripts/build.sh
+++ b/deploy/scripts/build.sh
@@ -36,7 +36,15 @@ mkdir -p $STAC_FASTAPI_SRC_DIR
 git clone https://github.com/stac-utils/stac-fastapi $STAC_FASTAPI_SRC_DIR/stac-fastapi
 CURRENT_WORKING_DIRECTORY="$(pwd)"
 cd $STAC_FASTAPI_SRC_DIR/stac-fastapi
-git reset --hard 926698034f836ed4db13e03c9c33257c4a86020a
+git reset --hard da012a635b1c0185d40595db11c76ac9f110d796
 cd $CURRENT_WORKING_DIRECTORY
+
+# This is temporary fix until we find a better solution for this fix
+# issue - pypgstac cmdline for ingesting the STAC collection and item are 
+# at 0.6.11 and the database (postgresql) is getting bootstrapped to 0.6.13.
+# These two versions need to match. This fix holds these versions to 0.6.11.
+sed -i 's/0.6.12/0.6.11/' $STAC_FASTAPI_SRC_DIR/stac-fastapi/docker-compose.yml
+sed -i 's/0.6.\*/0.6.11/' $STAC_FASTAPI_SRC_DIR/stac-fastapi/stac_fastapi/pgstac/setup.py
+
 az acr build --registry $ACR_NAME --image stac-fastapi ${STAC_FASTAPI_SRC_DIR}/stac-fastapi
 rm -rf ${STAC_FASTAPI_SRC_DIR}

--- a/src/azure-stac-cli/stac/processors/core/ingest_stac_collection.py
+++ b/src/azure-stac-cli/stac/processors/core/ingest_stac_collection.py
@@ -102,7 +102,7 @@ class StacCol2Postgres(BaseProcessor):
                     data = json.dumps(json.load(f))
                     
                     # send the json for ingestion to PostgreSQL
-                    cursor.callproc('pgstac.create_collection', [data])
+                    cursor.execute('SELECT pgstac.create_collection(%s)', [data])
 
                     conn.commit()
 

--- a/src/azure-stac-cli/stac/processors/naip/extract_stac_from_naip.py
+++ b/src/azure-stac-cli/stac/processors/naip/extract_stac_from_naip.py
@@ -246,8 +246,12 @@ class ExtractStac4mNaip(BaseProcessor):
                     
                     try:
                         # todo: fix this - takes 3 arguments; not one
-                        file_path, file_name = asyncio.run(
-                            download_blob_async(download_tif_url))
+                        asyncio.run(
+                            download_blob_async(conn_str=self.CONNECTION_STRING,
+                                                container_name=self.SRC_CONTAINER_NAME,
+                                                file_path=download_tif_url,
+                                                destination_path='./'))
+                        
                         
                         self.__translate_tif_to_jpeg(
                             file_name_without_ext, file_name)
@@ -259,7 +263,7 @@ class ExtractStac4mNaip(BaseProcessor):
                             asyncio.run(upload_blob_async(
                                 conn_string=self.CONNECTION_STRING,
                                 container_name=self.SRC_CONTAINER_NAME,
-                                file_path=file_path, 
+                                file_path='./', 
                                 file_name=file_to_upload))
 
                     except Exception as e:

--- a/src/azure-stac-cli/stac/setup.py
+++ b/src/azure-stac-cli/stac/setup.py
@@ -15,7 +15,8 @@ DEPENDENCIES= [
     'rasterio==1.3.4',
     'stactools==0.4.2',
     'psycopg[binary]==3.1.7',
-    'pypgstac[psycopg]==0.6.11'
+    'pypgstac[psycopg]==0.6.11',
+    'charset-normalizer<3.0,>=2.0'
 ],
 
 setup(


### PR DESCRIPTION
Includes:

1. Pypgstac versions mismatched - CLI Version and Database version not matching.
2. Processor code change due to change from Psycopg2 to Psycopg3 during the last PR.
3. Other minor fixes like edge case where the metadata file does not exists for a Geotiff fails.