### PR TITLE
Remove api management

### DIFF
--- a/deploy/bicep/groups/monitoring.bicep
+++ b/deploy/bicep/groups/monitoring.bicep
@@ -25,11 +25,8 @@ module appinsights '../modules/appinsights.bicep' = {
     environmentName: environmentTag
     applicationInsightsName: '${namingPrefix}-appinsights'
     location: location
-    workspaceId: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.OperationalInsights/workspaces/${namingPrefix}-workspace'
+    workspaceId: workspace.outputs.workspaceId
   }
-  dependsOn: [
-    workspace
-  ]
 }
 
 output workspaceId string = workspace.outputs.workspaceId

--- a/deploy/bicep/groups/processing.bicep
+++ b/deploy/bicep/groups/processing.bicep
@@ -5,7 +5,6 @@ param environmentCode string
 param environmentTag string
 param location string
 param projectName string
-param resourceGroupName string = resourceGroup().name
 
 param keyVaultName string
 param keyVaultResourceGroupName string
@@ -13,13 +12,6 @@ param logAnalyticsWorkspaceResourceID string
 param acrName string = ''
 param acrSku string = 'Standard'
 param kubernetesVersion string
-param storageAccountNameForApim string
-param storageAccountResourceGroupName string
-param loadBalancerPrivateIP string = '10.6.3.254'
-// Roles for APIM and its Managed Identity
-param apimMISRoles array = [
-  'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
-]
 
 // Parameters for Virtual Network Information
 param vnetName string
@@ -36,20 +28,6 @@ param aksUserAgentPools array = [
   }
 ]
 param aksNodePoolMaxPods int = 10
-param apiManagementServiceName string =''
-param apiManagementSku string = 'Premium'
-@allowed([
-  'None'
-  'External'
-  'Internal'
-])
-param apiVirtualNetworkType string = 'External'
-param apimSubnetId string = ''
-@allowed([
-  'stv1'
-  'stv2'
-])
-param apimPlatformVersion string = 'stv2'
 
 // Parameters for jumpbox
 param jumpboxVmName string = ''
@@ -73,346 +51,17 @@ param userManagedIdentityIdForJumpboxStateCheck string
 param azureBastionSubnetID string
 param azureBastionName string = ''
 
+param ingressPublicIPDnsPrefix string = 'stac'
+
 var namingPrefix = '${environmentCode}-${projectName}'
 var namingSuffix = substring(uniqueString(guid('${subscription().subscriptionId}${namingPrefix}${environmentTag}${location}')), 0, 10)
 var acrNameVar = empty(acrName) ? 'acr${namingSuffix}' : acrName
 var aksClusterNameVar = empty(aksClusterName) ? 'aks${namingSuffix}' : aksClusterName
 var aksManagedIdentityNameVar = empty(aksManagedIdentityName) ? '${namingPrefix}aks-mi' : aksManagedIdentityName
-var apiManagementServiceNameVar =  empty(apiManagementServiceName) ? 'apim-${namingSuffix}' : apiManagementServiceName
 var jumpboxVmNameVar = empty(jumpboxVmName) ? 'jbox${namingSuffix}' : jumpboxVmName
 var jumpboxAdminPasswordOrKeyVar = empty(jumpboxAdminPasswordOrKey) && jumpboxAuthenticationType == 'password' ?'${base64(uniqueString(guid(namingPrefix)))}' : jumpboxAdminPasswordOrKey
 var bastionNameVar = empty(azureBastionName)? 'bastion${namingSuffix}' : azureBastionName
-var apimStorageAccountBlobServiceUrl = 'https://${storageAccountNameForApim}.blob.${environment().suffixes.storage}'
-
-var apiOperationConfigs = [
-  {
-    properties: {
-      displayName: 'blobStore'
-      apiRevision: '1'
-      subscriptionRequired: true
-      serviceUrl: apimStorageAccountBlobServiceUrl
-      path: 'blobstore'
-      protocols: [
-        'https'
-      ]
-      isCurrent: true
-    }
-    policy: {
-      value: '''
-      <!--
-        IMPORTANT:
-        - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
-        - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
-        - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
-        - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
-        - To remove a policy, delete the corresponding policy statement from the policy document.
-        - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
-        - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
-        - Policies are applied in the order of their appearance, from the top down.
-        - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
-      -->
-      <policies>
-        <inbound>
-          <base />
-          <set-header name="x-ms-version" exists-action="override">
-            <value>2017-11-09</value>
-          </set-header>
-          <set-header name="x-ms-blob-type" exists-action="override">
-            <value>BlockBlob</value>
-          </set-header>
-          <authentication-managed-identity resource="https://storage.azure.com" />
-        </inbound>
-        <backend>
-          <base />
-        </backend>
-        <outbound>
-          <base />
-        </outbound>
-        <on-error>
-          <base />
-        </on-error>
-      </policies>
-      '''
-      format: 'rawxml'
-    }
-    operations: [
-      {
-        name: 'getblob'
-        policy: {}
-        properties: {
-          displayName: 'Get Blob'
-          method: 'GET'
-          urlTemplate: '/*'
-          templateParameters: []
-          description: 'getBlob'
-          responses: [
-            {
-              statusCode: 200
-            }
-          ]
-        }
-      }
-    ]
-  }
-  {
-    properties: {
-      displayName: 'fast-stac-api'
-      apiRevision: '1'
-      subscriptionRequired: false
-      serviceUrl: 'http://${loadBalancerPrivateIP}:8082'
-      path: 'api'
-      protocols: [
-        'https'
-      ]
-      isCurrent: true
-    }
-    policy: {
-      value: '''
-      <policies>
-        <inbound>
-          <base />
-          <set-header name="requestURL" exists-action="override">
-            <value>@((string)context.Request.OriginalUrl.Path.Trim('/').Substring(context.Api.Path.Trim('/').Length))</value>
-          </set-header>
-          <set-header name="Accept-Encoding" exists-action="override">
-            <value>*</value>
-          </set-header>
-        </inbound>
-        <backend>
-          <base />
-        </backend>
-        <outbound>
-          <!-- 
-            Rewrite storage account URLs to go through the blobstore proxy.
-            This assumes the blob-storage-url named value has been set to the
-            blob service endpoint for the storage account.
-          -->
-          <find-and-replace from="{{blob-storage-url}}" to="@{
-              // Get the Gateway URL by taking the scheme/host/port (if non-standard)
-              // of the APIM service, but leave off any path and/or query.
-              var url = context.Request.OriginalUrl;
-              var port = (url.Port == 80 || url.Port == 443) ? "" : (":" + url.Port);
-              return url.Scheme + "://" + url.Host + port + "/blobstore";
-          }" />
-          <!--
-              Rewrite any URLs in the body that reference the internal service.
-          -->
-          <redirect-content-urls />
-          <base />
-        </outbound>
-        <on-error>
-          <base />
-        </on-error>
-      </policies>
-      '''
-      format: 'rawxml'
-    }
-    operations: [
-      {
-        name: 'queryables'
-        policy: {}
-        properties: {
-          displayName: 'Queryables'
-          method: 'GET'
-          urlTemplate: '/queryables'
-          templateParameters: []
-          description: 'Queryables'
-          responses: []
-        }
-      }
-      {
-        name: 'conformance-classes'
-        policy: {}
-        properties: {
-          displayName: 'Conformance'
-          method: 'GET'
-          urlTemplate: '/conformance'
-          templateParameters: []
-          responses: []
-        }
-      }
-      {
-        name: 'get-search'
-        policy: {}
-        properties: {
-          displayName: 'Search Catalog (GET)'
-          method: 'GET'
-          urlTemplate: '/search'
-          templateParameters: []
-          description: '/search'
-          responses: [
-            {
-              statusCode: 200
-              representations: [
-                {
-                  contentType: 'application/json'
-                }
-              ]
-            }
-          ]
-        }
-      }
-      {
-        name: 'post-search'
-        policy: {}
-        properties: {
-          displayName: 'Search Catalog (POST)'
-          method: 'POST'
-          urlTemplate: '/search'
-          templateParameters: []
-          description: '''Cross catalog search (POST).
-          Called with `POST /search`.
-            Args:
-              search_request: search request parameters.
-            Returns:
-              ItemCollection containing items which match the search criteria.
-          '''
-          responses: [
-            {
-              statusCode: 200
-            }
-          ]
-        }
-      }
-      {
-        name: 'get-collections'
-        policy: {}
-        properties: {
-          displayName: 'List Collections'
-          method: 'GET'
-          urlTemplate: '/collections'
-          templateParameters: []
-          description: '''Get all collections.
-          Called with `GET /collections`.
-            Args: 
-            Returns:
-              Collection.
-          '''
-          responses: [
-            {
-              statusCode: 200
-            }
-          ]
-        }
-      }
-      {
-        name: 'get-collection-by-id'
-        policy: {}
-        properties: {
-          displayName: 'Get Collection'
-          method: 'GET'
-          urlTemplate: '/collections/{collection_id}'
-          templateParameters: [
-            {
-              name: 'collection_id'
-              required: true
-            }
-          ]
-          description: '''Get collection by id.
-          Called with `GET /collections/{collection_id}`.
-            Args:
-              collection_id: ID of the collection.
-            Returns:
-              Collection.
-          '''
-          responses: [
-            {
-              statusCode: 200
-            }
-          ]
-        }
-      }
-      {
-        name: 'get-collection-queryables'
-        policy: {}
-        properties: {
-          displayName: 'Collection Queryables'
-          method: 'GET'
-          urlTemplate: '/collections/{collection_id}/queryables'
-          templateParameters: [
-            {
-              name: 'collection_id'
-              required: true
-            }
-          ]
-          description: '''Get collection queryables.
-          Called with `GET /collections/{collection_id}/querables`.
-            Args:
-              collection_id: ID of the collection.
-            Returns:
-              Qyeryables.
-          '''
-          responses: [
-            {
-              statusCode: 200
-            }
-          ]
-        }
-      }
-      {
-        name: 'collections-collection-id-items'
-        policy: {}
-        properties: {
-          displayName: 'List Items in Collection'
-          method: 'GET'
-          urlTemplate: '/collections/{collection_id}/items'
-          templateParameters: [
-            {
-              name: 'collection_id'
-              required: true
-            }
-          ]
-          description: '''Get all items from a specific collection.
-          Called with `GET /collections/{collection_id}/items`
-            Args:
-              collection_id: id of the collection.
-              limit: number of items to return.
-              token: pagination token.
-            Returns:
-              An ItemCollection.
-          '''
-          responses: [
-            {
-              statusCode: 200
-            }
-          ]
-        }
-      }
-      {
-        name: 'collections-collection-id-items-item-id'
-        policy: {}
-        properties: {
-          displayName: 'Get Item'
-          method: 'GET'
-          urlTemplate: '/collections/{collection_id}/items/{item_id}'
-          templateParameters: [
-            {
-              name: 'collection_id'
-              required: true
-            }
-            {
-              name: 'item_id'
-              required: true
-            }
-          ]
-          description: '''Get item by id.
-          Called with `GET /collections/{collection_id}/items/{item_id}`.
-            Args:
-              item_id: ID of the item.
-              collection_id: ID of the collection the item is in.
-            Returns:
-              Item.
-          '''
-          responses: [
-            {
-              statusCode: 200
-            }
-          ]
-        }
-      }
-    ]
-  }
-]
+var ingressPublicIPDnsPrefixVar = empty(ingressPublicIPDnsPrefix) ? 'stac-${namingSuffix}' : ingressPublicIPDnsPrefix
 
 module acr '../modules/acr.bicep' = {
   name: '${namingPrefix}-acr'
@@ -428,13 +77,10 @@ module acrCredentials '../modules/acr.credentials.to.keyvault.bicep' = {
   name: '${namingPrefix}-acr-credentials'
   params: {
     environmentName: environmentTag
-    acrName: acrNameVar
+    acrName: acr.outputs.name
     keyVaultName: keyVaultName
     keyVaultResourceGroup: keyVaultResourceGroupName
   }
-  dependsOn: [
-    acr
-  ]
 }
 
 module aksManagedIdentity '../modules/managed.identity.user.bicep' = {
@@ -471,19 +117,23 @@ module aksCluster '../modules/aks-cluster.bicep' =  {
     networkPlugin: 'kubenet'
     vnetSubnetID: vnetSubnetID
     kubernetesVersion: kubernetesVersion
-    clientId: aksManagedIdentity.outputs.uamiClientId
   }
-  dependsOn: [
-    acr
-    aksManagedIdentity
-  ]
 }
 
-module grantNetworkContributorToAksCluster '../modules/vnet.role-assignment.bicep' = {
+module grantNetworkContributorOnVnetRGToAksCluster '../modules/vnet.role-assignment.bicep' = {
   name: '${namingPrefix}-aks-grant-network-contributor-on-vnet'
   scope: resourceGroup(vnetResourceGroup)
   params: {
     vnetName: vnetName
+    principalId: aksCluster.outputs.principalId
+    // Role definition id maps to 'Network Contributor' role
+    roleDefinitionId: '/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7'
+  }
+}
+
+module grantNetworkContributorOnProcessingRGToAksCluster '../modules/resourcegroup.role-assignment.bicep' = {
+  name: '${namingPrefix}-aks-grant-network-contributor-on-processing-rg'
+  params: {
     principalId: aksCluster.outputs.principalId
     // Role definition id maps to 'Network Contributor' role
     roleDefinitionId: '/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7'
@@ -503,85 +153,20 @@ module attachACRtoAKS '../modules/aks-attach-acr.bicep' =  {
   name: '${namingPrefix}-attachACRtoAKS'
   params: {
     kubeletIdentityId: aksCluster.outputs.kubeletIdentityId
-    acrName:  acrNameVar
+    acrName:  acr.outputs.name
   }
-  dependsOn: [
-    acr
-    aksCluster
-  ]
 }
 
 module addUserAgentPools '../modules/aks-add-nodepool.bicep' = [ for (config, index) in aksUserAgentPools: {
   name: '${namingPrefix}-addUserAgentPools-${index}'
   params: {
-    clusterName: aksClusterNameVar
+    clusterName: aksCluster.outputs.name
     agentPoolName: config.name
     count: config.count
     maxPods: aksNodePoolMaxPods
     nodeLable: {
       env: config.name
     }
-  }
-  dependsOn: [
-    aksCluster
-  ]
-}]
-
-module apim '../modules/apim.bicep' ={
-  name : '${namingPrefix}-apim'
-  params: {
-    apiManagementServiceName: apiManagementServiceNameVar
-    publisherEmail: 'admin@${resourceGroupName}.notexist'
-    publisherName: resourceGroupName
-    sku: apiManagementSku
-    location: location
-    virtualNetworkType: apiVirtualNetworkType
-    subnetId: apimSubnetId
-    platformVersion: apimPlatformVersion
-  }
-}
-
-module apimApis '../modules/apim.api.bicep' = [ for (config, index) in apiOperationConfigs: {
-  name: '${namingPrefix}-apim-api-${index}'
-  params: {
-    parentResourceName: apim.outputs.name
-    apiName: config.properties.displayName
-    properties: config.properties
-    policy: config.policy
-  }
-  dependsOn: [
-    apimMSIStorageRoleAssignment
-  ]
-}]
-
-module apimApiOperations '../modules/apim.api.operations.bicep' = [ for (config, index) in apiOperationConfigs: {
-  name: '${namingPrefix}-apim-api-operations-${index}'
-  params: {
-    apiManagementName: apim.outputs.name
-    apiName: config.properties.displayName
-    operations: config.operations
-  }
-  dependsOn: [
-    apimApis
-  ]
-}]
-
-module apimNamedValues '../modules/apim.namedValues.bicep' = {
-  name: '${namingPrefix}-apim-namedValues'
-  params: {
-    apiManagementServiceName: apim.outputs.name
-    name: 'blob-storage-url'
-    value: apimStorageAccountBlobServiceUrl
-  }
-}
-
-module apimMSIStorageRoleAssignment '../modules/storage-role-assignment.bicep' = [ for (role, index) in apimMISRoles: {
-  name: '${namingPrefix}-api-storageRole-${index}'
-  scope: resourceGroup(storageAccountResourceGroupName)
-  params: {
-    resourceName: storageAccountNameForApim
-    principalId: apim.outputs.principalId
-    roleDefinitionId: '/subscriptions/${subscription().subscriptionId}/providers/Microsoft.Authorization/roleDefinitions/${role}'
   }
 }]
 
@@ -614,9 +199,6 @@ module jumpboxVmCredentials '../modules/vm.credentials.to.keyvault.bicep' = if (
     vmUsername: jumpboxAdminUsername
     vmPassword: (jumpboxAuthenticationType == 'password')?jumpboxAdminPasswordOrKeyVar:'use-ssh-key'
   }
-  dependsOn: [
-    jumpbox
-  ]
 }
 
 module azureBastion '../modules/bastion.bicep'= {
@@ -630,5 +212,13 @@ module azureBastion '../modules/bastion.bicep'= {
   dependsOn: [
     jumpbox
   ]
+}
 
+module ingressPublicIP '../modules/publicip.bicep' = {
+  name: '${namingPrefix}-ingress-public-ip'
+  params: {
+    location: location
+    name: '${namingPrefix}-ingress-public-ip'
+    dnsLabelPrefix: ingressPublicIPDnsPrefixVar
+  }
 }

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -40,8 +40,8 @@ param jumpboxAdminPassword string
 @description('Disable private endpoint for PostgreSQL')
 param privateEndpointDisabled bool = false
 
-@description('Platform Version for API Management Service')
-param apimPlatformVersion string = 'stv2'
+@description('Ingress Public IP DNS Label Prefix (optional)')
+param ingressPublicIPDnsPrefix string = ''
 
 // Guid to role definitions to be used during role
 // assignments including the below roles definitions:
@@ -54,8 +54,6 @@ var dataResourceGroupName = '${environmentCode}-data-rg'
 var processingResourceGroupName = '${environmentCode}-processing-rg'
 var projectName = 'stac'
 var namingPrefix = '${environmentCode}-${projectName}'
-
-param loadBalancerPrivateIP string = '10.6.3.254'
 
 // This parameter is a placeholder to retain current work we have for public access
 // Setting it to true may not work for all cases.
@@ -222,12 +220,8 @@ module processingModule 'groups/processing.bicep' = {
     jumpboxSubnetID: networkingModule.outputs.jumpboxSubnetId
     jumpboxAdminUsername: jumpboxAdminUsername
     jumpboxAdminPasswordOrKey: jumpboxAdminPassword
-    loadBalancerPrivateIP: loadBalancerPrivateIP
-    storageAccountNameForApim: dataModule.outputs.storageAccountName
-    storageAccountResourceGroupName: dataRg.name
-    apimSubnetId: networkingModule.outputs.apimSubnetId
     azureBastionSubnetID: networkingModule.outputs.bastionSubnetId
-    apimPlatformVersion: apimPlatformVersion
+    ingressPublicIPDnsPrefix: ingressPublicIPDnsPrefix
   }
   dependsOn: [
     dataModule

--- a/deploy/bicep/modules/acr.bicep
+++ b/deploy/bicep/modules/acr.bicep
@@ -23,3 +23,5 @@ resource containerRepoitory 'Microsoft.ContainerRegistry/registries@2021-12-01-p
     zoneRedundancy: (zoneRedundancy) ? 'Enabled' : 'Disabled'
   }
 }
+
+output name string = containerRepoitory.name

--- a/deploy/bicep/modules/aks-add-nodepool.bicep
+++ b/deploy/bicep/modules/aks-add-nodepool.bicep
@@ -24,7 +24,7 @@ resource aksNodePool 'Microsoft.ContainerService/managedClusters/agentPools@2022
     mode: agentPoolMode
     type: 'VirtualMachineScaleSets'
     nodeLabels: nodeLable
-    vnetSubnetID: (empty(vnetSubnetID) ? json('null') : vnetSubnetID)
+    vnetSubnetID: (empty(vnetSubnetID) ? null : vnetSubnetID)
     enableAutoScaling: enableAutoScaling
     scaleDownMode: 'Delete'
     maxPods: maxPods

--- a/deploy/bicep/modules/aks-attach-acr.bicep
+++ b/deploy/bicep/modules/aks-attach-acr.bicep
@@ -4,8 +4,6 @@
 param kubeletIdentityId string
 param acrName string
 param roleAssignmentId string = guid(kubeletIdentityId, kubeletIdentityId, acrName)
-//this RoleId maps to AcrPull role
-var acrPullRoleId = '/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d'
 
 resource acr 'Microsoft.ContainerRegistry/registries@2021-12-01-preview' existing = {
   name: acrName
@@ -16,6 +14,12 @@ resource acrPullRole 'Microsoft.Authorization/roleAssignments@2020-10-01-preview
   scope: acr
   properties: {
     principalId: kubeletIdentityId
-    roleDefinitionId: acrPullRoleId
+    roleDefinitionId: acrPullRoleDefinition.id
   }
+}
+
+@description('This is the built-in AcrPull role. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#acrpull')
+resource acrPullRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  name: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
 }

--- a/deploy/bicep/modules/aks-cluster.bicep
+++ b/deploy/bicep/modules/aks-cluster.bicep
@@ -10,10 +10,9 @@ param networkPlugin string = 'azure'
 param networkMode string = 'transparent'
 param logAnalyticsWorkspaceResourceID string = ''
 param vnetSubnetID string = ''
-param clientId string = ''
 param kubernetesVersion string = '1.25.4'
 
-resource aks 'Microsoft.ContainerService/managedClusters@2022-09-02-preview' = {
+resource aks 'Microsoft.ContainerService/managedClusters@2023-01-02-preview' = {
   name: clusterName
   location: location
   tags: {
@@ -39,7 +38,7 @@ resource aks 'Microsoft.ContainerService/managedClusters@2022-09-02-preview' = {
         nodeLabels: {
           App : 'default'
         }
-        vnetSubnetID: (empty(vnetSubnetID) ? json('null') : vnetSubnetID)
+        vnetSubnetID: (empty(vnetSubnetID) ? null : vnetSubnetID)
       }
     ]
     addonProfiles: {
@@ -51,9 +50,6 @@ resource aks 'Microsoft.ContainerService/managedClusters@2022-09-02-preview' = {
       }
       azureKeyvaultSecretsProvider: {
         enabled: true
-        identity: {
-          clientId: clientId
-        }
       }
     }
     networkProfile: {
@@ -68,6 +64,9 @@ resource aks 'Microsoft.ContainerService/managedClusters@2022-09-02-preview' = {
   }
 }
 
+output name string = aks.name
 output Id string = aks.id
 output principalId string = aks.identity.principalId
 output kubeletIdentityId string = aks.properties.identityProfile.kubeletidentity.objectId
+output managedResourceGroup string = aks.properties.nodeResourceGroup
+output podCidr string = aks.properties.networkProfile.podCidr

--- a/deploy/bicep/modules/akv.bicep
+++ b/deploy/bicep/modules/akv.bicep
@@ -73,4 +73,5 @@ resource akv 'Microsoft.KeyVault/vaults@2021-11-01-preview' = {
   }
 }
 
+output name string = akv.name
 output vaultUri string = akv.properties.vaultUri

--- a/deploy/bicep/modules/assign-managed-identity-operator-to-aks.bicep
+++ b/deploy/bicep/modules/assign-managed-identity-operator-to-aks.bicep
@@ -4,8 +4,6 @@
 param aksClusterPrincipalId string
 param managedIdentityName string
 
-// managedIdentityOperatorRole is mapped to role definition "Managed Identity Operator"
-param managedIdentityOperatorRole string = '/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830'
 param roleAssignmentId string = guid(managedIdentityName, aksClusterPrincipalId)
 
 resource aadPodIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2021-09-30-preview' existing = {
@@ -17,9 +15,15 @@ resource ManagedIdentityRoleAssignment 'Microsoft.Authorization/roleAssignments@
   scope: aadPodIdentity
   properties: {
     principalId: aksClusterPrincipalId
-    roleDefinitionId: managedIdentityOperatorRole
+    roleDefinitionId: managedIdentityOperatorRoleDefinition.id
   }
   dependsOn:[
     aadPodIdentity   
   ]
+}
+
+@description('This is the built-in AcrPull role. See https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#managed-identity-operator')
+resource managedIdentityOperatorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' existing = {
+  scope: subscription()
+  name: 'f1a07417-d97a-45cb-824c-7a7467783830'
 }

--- a/deploy/bicep/modules/eventgrid.bicep
+++ b/deploy/bicep/modules/eventgrid.bicep
@@ -38,4 +38,5 @@ resource diagnosticLogs 'Microsoft.Insights/diagnosticSettings@2021-05-01-previe
   }
 }
 
+output name string = eventGridTopic.name
 output principalId string = eventGridTopic.identity.principalId

--- a/deploy/bicep/modules/postgres.flexible.svc.bicep
+++ b/deploy/bicep/modules/postgres.flexible.svc.bicep
@@ -29,8 +29,8 @@ resource serverName_resource 'Microsoft.DBforPostgreSQL/flexibleServers@2021-06-
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
     network: privateEndpointDisabled ? null: {
-      delegatedSubnetResourceId: (empty(delegatedSubnetResourceId) ? json('null') : delegatedSubnetResourceId)
-      privateDnsZoneArmResourceId: (empty(privateDnsZoneArmResourceId) ? json('null') : privateDnsZoneArmResourceId)
+      delegatedSubnetResourceId: (empty(delegatedSubnetResourceId) ? null : delegatedSubnetResourceId)
+      privateDnsZoneArmResourceId: (empty(privateDnsZoneArmResourceId) ? null : privateDnsZoneArmResourceId)
     }
     highAvailability: {
       mode: haMode

--- a/deploy/bicep/modules/publicip.bicep
+++ b/deploy/bicep/modules/publicip.bicep
@@ -29,3 +29,4 @@ resource publicIP 'Microsoft.Network/publicIPAddresses@2022-01-01' = {
 
 output id string = publicIP.id
 output hostname string = publicIP.properties.dnsSettings.fqdn
+output ipAddress string = publicIP.properties.ipAddress

--- a/deploy/bicep/modules/servicebus.bicep
+++ b/deploy/bicep/modules/servicebus.bicep
@@ -32,5 +32,6 @@ resource servicebus_RootManageSharedAccessKey 'Microsoft.ServiceBus/namespaces/A
   }
 }
 
+output name string = servicebus.name
 output authorizationRuleId string = servicebus_RootManageSharedAccessKey.id
 output authorizationRuleName string = servicebus_RootManageSharedAccessKey.name

--- a/deploy/bicep/modules/storage.bicep
+++ b/deploy/bicep/modules/storage.bicep
@@ -35,5 +35,6 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-08-01' = {
   }
 }
 
+output name string = storageAccount.name
 output storageAccountId string = storageAccount.id
 output fileEndpointUri string = storageAccount.properties.primaryEndpoints.file

--- a/deploy/bicep/modules/storage.credentials.to.keyvault.bicep
+++ b/deploy/bicep/modules/storage.credentials.to.keyvault.bicep
@@ -33,6 +33,6 @@ module storageAccountConnStrSecret './akv.secrets.bicep' = {
     environmentName: environmentName
     keyVaultName: keyVaultName
     secretName: storageAccountConnStrSecretNameVar
-    secretValue: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${listKeys(storageAccount.id, storageAccount.apiVersion).keys[0].value}'
+    secretValue: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
   }
 }

--- a/deploy/bicep/modules/vnet.bicep
+++ b/deploy/bicep/modules/vnet.bicep
@@ -25,3 +25,4 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 }
 
 output id string = vnet.id
+output name string = vnet.name

--- a/deploy/data/claims.json
+++ b/deploy/data/claims.json
@@ -1,0 +1,38 @@
+{
+  "idToken": [
+    {
+      "name": "upn",
+      "source": null,
+      "essential": false,
+      "additionalProperties": []
+    },
+    {
+      "name": "groups",
+      "source": null,
+      "essential": false,
+      "additionalProperties": []
+    },
+    {
+      "name": "preferred_username",
+      "source": null,
+      "essential": false,
+      "additionalProperties": []
+    }
+  ],
+  "accessToken": [
+    {
+      "name": "groups",
+      "source": null,
+      "essential": false,
+      "additionalProperties": []
+    }
+  ],
+  "saml2Token": [
+    {
+      "name": "groups",
+      "source": null,
+      "essential": false,
+      "additionalProperties": []
+    }
+  ]
+}

--- a/deploy/data/resource_access.json
+++ b/deploy/data/resource_access.json
@@ -1,0 +1,15 @@
+[
+  {
+    "resourceAppId": "00000003-0000-0000-c000-000000000000",
+    "resourceAccess": [
+      {
+        "id": "14dad69e-099b-42c9-810b-d002981feec1",
+        "type": "Scope"
+      },
+      {
+        "id": "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+        "type": "Scope"
+      }
+    ]
+  }
+]

--- a/deploy/data/roles.json
+++ b/deploy/data/roles.json
@@ -1,0 +1,22 @@
+[
+  {
+    "allowedMemberTypes": [
+      "User"
+    ],
+    "description": "STAC Writers can modify items in the catalog as well as add and remove items and collections.",
+    "displayName": "STAC Writers",
+    "isEnabled": true,
+    "origin": "Application",
+    "value": "STAC.Write"
+  },
+  {
+    "allowedMemberTypes": [
+      "User"
+    ],
+    "description": "STAC Readers can read data from the STAC.",
+    "displayName": "STAC Readers",
+    "isEnabled": true,
+    "origin": "Application",
+    "value": "STAC.Read"
+  }
+]

--- a/deploy/helm/stac-browser/Chart.yaml
+++ b/deploy/helm/stac-browser/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: stac-browser
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "3.0.0"

--- a/deploy/helm/stac-browser/templates/deployment.yaml
+++ b/deploy/helm/stac-browser/templates/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stac-browser
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: stac-browser
+  template:
+    metadata:
+      labels:
+        {{- toYaml .Values.labels | nindent 8 }}
+    spec:
+      nodeSelector:
+        "kubernetes.io/os": linux
+      containers:
+        - name: stac-browser
+          image: "{{ .Values.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}          
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+      restartPolicy: Always

--- a/deploy/helm/stac-browser/templates/ingress.yaml
+++ b/deploy/helm/stac-browser/templates/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stac-browser
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.clusterIssuer }}
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - {{ .Values.hostname }}
+    secretName: stac-certificate
+  rules:
+  - host: {{ .Values.hostname }}
+    http:
+      paths:
+      - path: {{ .Values.rootPath }}(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: stac-browser
+            port:
+              number: 8080

--- a/deploy/helm/stac-browser/templates/service.yaml
+++ b/deploy/helm/stac-browser/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stac-browser
+spec:
+  type: ClusterIP
+  ports:
+    - name: "8080"
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: stac-browser

--- a/deploy/helm/stac-browser/values.yaml
+++ b/deploy/helm/stac-browser/values.yaml
@@ -1,0 +1,19 @@
+# Default values for stac-browser.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+envCode: stac
+
+replicas: 1
+rootPath: /browser
+hostname: ~
+clusterIssuer: letsencrypt
+labels:
+  app: stac-browser
+image:
+  name: stac-browser
+  pullPolicy: Always
+  tag: "latest"
+

--- a/deploy/helm/stac-scaler/README.md
+++ b/deploy/helm/stac-scaler/README.md
@@ -1,9 +1,13 @@
 
 # Azure Orbital STAC Processor
 
-This chart deploys a [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/) that runs the STAC Processor on files stored in Azure Blob Storage.
+This chart deploys a [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+that runs the STAC Processor on files stored in Azure Blob Storage.
 
-The steps covered in this document is automated as part of main deployment covered in the [README.md](../../README.md). If you would like to customize and/or contribute to this Chart, follow the steps in this document to deploy the Kubernetes components to your Azure Kubernetes Cluster.
+The steps covered in this document is automated as part of main deployment
+covered in the [README.md](../../README.md). If you would like to customize
+and/or contribute to this Chart, follow the steps in this document to deploy
+the Kubernetes components to your Azure Kubernetes Cluster.
 
 ## Pre-requisites
 
@@ -16,27 +20,37 @@ The tools below are required for installation of the `stac-scaler` Chart.
 
 ## Installation
 
-Before executing the script, user needs to login to azure as shown below and set the correct subscription in which they want to provision the resources.
+Before executing the script, user needs to login to azure as shown below and
+set the correct subscription in which they want to provision the resources.
 
 ```
 az login
 
 az account set -s <subscription_id>
 ```
-One of pre-requisites for installing this Chart is [KEDA](https://keda.sh/docs/2.8/concepts/). KEDA is a Kubernetes based Event Driven Autoscaler. With KEDA, you can drive the scaling of any container in Kubernetes based on the number of events needing to be processed.
+One of pre-requisites for installing this Chart is [KEDA](https://keda.sh/docs/2.10/concepts/).
+KEDA is a Kubernetes based Event Driven Autoscaler. With KEDA, you can drive
+the scalingof any container in Kubernetes based on the number of events needing
+to be processed.
 
 ```
-kubectl apply -f https://github.com/kedacore/keda/releases/download/v2.8.0/keda-2.8.0.yaml
+helm repo add kedacore https://kedacore.github.io/charts
+helm repo update
+kubectl create namespace keda
+helm upgrade --install keda kedacore/keda --namespace keda
 ```
 
-In order to install the `STAC Processor` chart, it is recommended you first create a values-custom.yaml file in the current directory. Then the chart can be deployed with:
+In order to install the `STAC Processor` chart, it is recommended you first
+create a values-custom.yaml file in the current directory. Then the chart can
+be deployed with:
 
 ```
 helm install [-n <my_namespace>] <release_name> . -f values-custom.yaml
 ```
 ## Values
 
-This section of the document will go over all the possible values you can override in `values-custom.yaml` file in the current directory.
+This section of the document will go over all the possible values you can
+override in `values-custom.yaml` file in the current directory.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -49,7 +63,9 @@ This section of the document will go over all the possible values you can overri
 
 ### Processor
 
-A `processor` entry must have values as described below. Each `processor` entry defines a image to be pull from the ACR and run in the Kubernetes Cluster as Jobs through scaling.
+A `processor` entry must have values as described below. Each `processor` entry
+defines a image to be pull from the ACR and run in the Kubernetes Cluster as
+Jobs through scaling.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|

--- a/deploy/helm/stac-scaler/templates/deployment.yaml
+++ b/deploy/helm/stac-scaler/templates/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deployment-app-stacfastapi
-  namespace: {{ .Values.deploymentNamespace }}
 spec:
   replicas: {{ .Values.stacfastapi.replicas }}
   selector:
@@ -20,7 +19,7 @@ spec:
         - args:
             - bash
             - -c
-            - ./scripts/wait-for-it.sh {{ .Values.stacfastapi.env.PGHOST }}:{{ .Values.stacfastapi.env.POSTGRES_PORT }} && pypgstac pgready && pypgstac migrate && python -m stac_fastapi.pgstac.app
+            - ./scripts/wait-for-it.sh {{ .Values.stacfastapi.env.PGHOST }}:{{ .Values.stacfastapi.env.POSTGRES_PORT }} && pypgstac pgready && pypgstac migrate && uvicorn --root-path "{{ .Values.stacfastapi.rootPath }}" --proxy-headers --host 0.0.0.0 --port 8082 stac_fastapi.pgstac.app:app
           image: "{{ .Values.repository }}/{{ .Values.stacfastapi.image.name }}:{{ .Values.stacfastapi.image.tag }}"
           imagePullPolicy: {{ .Values.stacfastapi.image.pullPolicy }}
           name: stacfastapi-pgstac

--- a/deploy/helm/stac-scaler/templates/ingress.yaml
+++ b/deploy/helm/stac-scaler/templates/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fast-stac-api
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.stacfastapi.clusterIssuer }}
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      # Clear the Accept-Encoding header in order to avoid gzip compression
+      proxy_set_header Accept-Encoding '';
+      # Rewrite storage URLs to point to the blobstore proxy
+      subs_filter {{ .Values.stacfastapi.blobStoreEndpoint }} https://$host/blobstore/;
+      subs_filter_types application/json application/geo+json application/schema+json;
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - {{ .Values.stacfastapi.hostname }}
+    secretName: stac-certificate
+  rules:
+  - host: {{ .Values.stacfastapi.hostname }}
+    http:
+      paths:
+      - path: {{ .Values.stacfastapi.rootPath }}(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: app-stacfastapi
+            port:
+              number: 8082

--- a/deploy/helm/stac-scaler/templates/proc-gen-stac-deploy.yaml
+++ b/deploy/helm/stac-scaler/templates/proc-gen-stac-deploy.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: processor-generate-stac-json
-  namespace: {{ .Values.deploymentNamespace }}
 {{- with .Values.processors.generatestacjson }}
 spec:
   replicas: 3

--- a/deploy/helm/stac-scaler/templates/proc-stac-col-deploy.yaml
+++ b/deploy/helm/stac-scaler/templates/proc-stac-col-deploy.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: processor-stac-collection
-  namespace: {{ .Values.deploymentNamespace }}
 {{- with .Values.processors.staccollection }}
 spec:
   replicas: 3

--- a/deploy/helm/stac-scaler/templates/proc-stac-evnt-deploy.yaml
+++ b/deploy/helm/stac-scaler/templates/proc-stac-evnt-deploy.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: processor-stac-event-consumer
-  namespace: {{ .Values.deploymentNamespace }}
 {{- with .Values.processors.staceventconsumer }}
 spec:
   replicas: 3

--- a/deploy/helm/stac-scaler/templates/secrets-provider.yaml
+++ b/deploy/helm/stac-scaler/templates/secrets-provider.yaml
@@ -2,7 +2,6 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: azure-stac-keyvault-wi
-  namespace: {{ .Values.deploymentNamespace }}
 spec:
   provider: azure
   secretObjects:
@@ -54,4 +53,4 @@ spec:
         - |
           objectName: AppInsightsConnectionString
           objectType: secret
-    tenantId: {{ .Values.tenantId }}
+    tenantID: {{ .Values.tenantId }}

--- a/deploy/helm/stac-scaler/templates/service-account.yaml
+++ b/deploy/helm/stac-scaler/templates/service-account.yaml
@@ -6,4 +6,3 @@ metadata:
   labels:
     azure.workload.identity/use: "true"
   name: {{ .Values.serviceAccountName }}
-  namespace: {{ .Values.deploymentNamespace }}

--- a/deploy/helm/stac-scaler/templates/service.yaml
+++ b/deploy/helm/stac-scaler/templates/service.yaml
@@ -2,13 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: app-stacfastapi
-  namespace: {{ .Values.deploymentNamespace }}
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-    service.beta.kubernetes.io/azure-dns-label-name: app-stacfastapi-{{ .Values.envCode }}
 spec:
-  type: LoadBalancer
-  loadBalancerIP: {{ .Values.stacfastapi.privateIp }}
+  type: ClusterIP
   ports:
     - name: "8082"
       port: 8082

--- a/deploy/helm/stac-scaler/values.yaml
+++ b/deploy/helm/stac-scaler/values.yaml
@@ -11,7 +11,6 @@ activeDeadlineSeconds: 600
 
 # repository: myacr.azurecr.io
 
-deploymentNamespace: pgstac
 envCode: stac
 
 processors:
@@ -100,7 +99,10 @@ processors:
 
 stacfastapi:
   replicas: 1
-  # privateIp: "" # 10.6.3.15
+  rootPath: /api
+  blobStoreEndpoint: ~
+  hostname: ~
+  clusterIssuer: letsencrypt
   labels:
     app: app-stacfastapi
   image:

--- a/deploy/scripts/build.sh
+++ b/deploy/scripts/build.sh
@@ -6,27 +6,42 @@
 PRJ_ROOT="$(cd `dirname "${BASH_SOURCE}"`/../..; pwd)"
 ENV_CODE=${1:-${ENV_CODE}}
 
-if [[ -z "$ENV_CODE" ]]
-  then
-    echo "Environment Code value not supplied"
-    exit 1
-fi
+[[ -z "$ENV_CODE" ]] && { echo "Environment Code value not supplied"; exit 1; }
 
 set -ae
 ENV_NAME=${ENV_NAME:-"stac-${ENV_CODE}"}
-STAC_FASTAPI_VERSION=${STAC_FASTAPI_VERSION:-"2.4.4"}
+STAC_FASTAPI_VERSION=${STAC_FASTAPI_VERSION:-"2.4.5"}
+STAC_BROWSER_VERSION=${STAC_BROWSER_VERSION:-"3.0.0"}
 PROCESSING_RESOURCE_GROUP=${PROCESSING_RESOURCE_GROUP:-"${ENV_CODE}-processing-rg"}
 
 ACR_NAME=$(az acr list -g ${PROCESSING_RESOURCE_GROUP} \
     --query "[?tags.environment && tags.environment == '$ENV_NAME'].name" -otsv)
 
-az acr build --registry $ACR_NAME --image stac-cli ${PRJ_ROOT}
+echo "Building stac-cli Docker image in ACR"
+az acr build -o none --no-logs --registry $ACR_NAME --image stac-cli ${PRJ_ROOT}
 
 # build stac-fastapi from https://github.com/stac-utils/stac-fastapi/archive/refs/tags/${STAC_FASTAPI_VERSION}.tar.gz
 STAC_FASTAPI_SRC_DIR=${STAC_FASTAPI_SRC_DIR:-"${PRJ_ROOT}/src/stac_fastapi_k8s/src"}
 STAC_FASTAPI_RELEASE_URI=${STAC_FASTAPI_RELEASE_URI:-"https://github.com/stac-utils/stac-fastapi/archive/refs/tags/${STAC_FASTAPI_VERSION}.tar.gz"}
 mkdir -p $STAC_FASTAPI_SRC_DIR
 wget $STAC_FASTAPI_RELEASE_URI -P $STAC_FASTAPI_SRC_DIR
-tar xvf ${STAC_FASTAPI_SRC_DIR}/${STAC_FASTAPI_VERSION}.tar.gz -C ${STAC_FASTAPI_SRC_DIR}
-az acr build --registry $ACR_NAME --image stac-fastapi --file ${STAC_FASTAPI_SRC_DIR}/stac-fastapi-${STAC_FASTAPI_VERSION}/docker/Dockerfile ${STAC_FASTAPI_SRC_DIR}/stac-fastapi-${STAC_FASTAPI_VERSION}
+tar xf ${STAC_FASTAPI_SRC_DIR}/${STAC_FASTAPI_VERSION}.tar.gz -C ${STAC_FASTAPI_SRC_DIR}
+echo "Building stac-fastapi Docker image in ACR"
+az acr build -o none --no-logs --registry $ACR_NAME --image stac-fastapi \
+  --file ${STAC_FASTAPI_SRC_DIR}/stac-fastapi-${STAC_FASTAPI_VERSION}/docker/Dockerfile \
+  ${STAC_FASTAPI_SRC_DIR}/stac-fastapi-${STAC_FASTAPI_VERSION}
 rm -rf ${STAC_FASTAPI_SRC_DIR}
+
+# build stac-browser from https://github.com/radiantearth/stac-browser/archive/refs/tags/v${STAC_BROWSER_VERSION}.tar.gz
+FQDN=$(az network public-ip show -g $PROCESSING_RESOURCE_GROUP -n ${ENV_CODE}-stac-ingress-public-ip \
+    --query dnsSettings.fqdn -o tsv)
+STAC_BROWSER_SRC_DIR=${STAC_BROWSER_SRC_DIR:-"${PRJ_ROOT}/src/stac_browser_k8s/src"}
+STAC_BROWSER_RELEASE_URI=${STAC_BROWSER_RELEASE_URI:-"https://github.com/radiantearth/stac-browser/archive/refs/tags/v${STAC_BROWSER_VERSION}.tar.gz"}
+mkdir -p $STAC_BROWSER_SRC_DIR
+wget $STAC_BROWSER_RELEASE_URI -P $STAC_BROWSER_SRC_DIR
+tar xf ${STAC_BROWSER_SRC_DIR}/v${STAC_BROWSER_VERSION}.tar.gz -C ${STAC_BROWSER_SRC_DIR}
+echo "Building stac-browser Docker image in ACR"
+az acr build -o none --no-logs --registry $ACR_NAME --image stac-browser \
+  --build-arg 'catalogURL='"'"'https://'$FQDN'/api/ --pathPrefix="/browser/"'"'"'' \
+  ${STAC_BROWSER_SRC_DIR}/stac-browser-${STAC_BROWSER_VERSION}
+rm -rf ${STAC_BROWSER_SRC_DIR}

--- a/deploy/scripts/cleanup.sh
+++ b/deploy/scripts/cleanup.sh
@@ -6,11 +6,10 @@
 # parameters
 ENV_CODE=${1:-${ENV_CODE}}
 
-if [[ -z "$ENV_CODE" ]]
-  then
-    echo "Environment Code value not supplied"
-    exit 1
-fi
+[[ -z "$ENV_CODE" ]] && { echo "Environment Code value not supplied"; exit 1; }
+
+ENV_TAG=${ENV_TAG:-"stac-${ENV_CODE}"}
+DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-"${ENV_TAG}-deploy"}
 
 # variables
 MONITORING_RESOURCE_GROUP="${ENV_CODE}-monitoring-rg"
@@ -27,3 +26,4 @@ az group delete --name ${DATA_RESOURCE_GROUP} --no-wait --yes
 az deployment sub delete --name ${DATA_RESOURCE_GROUP} --no-wait
 az group delete --name ${PROCESSING_RESOURCE_GROUP} --no-wait --yes
 az deployment sub delete --name ${PROCESSING_RESOURCE_GROUP} --no-wait
+az deployment sub delete --name ${DEPLOYMENT_NAME} --no-wait

--- a/deploy/scripts/configure.sh
+++ b/deploy/scripts/configure.sh
@@ -5,14 +5,13 @@
 
 PRJ_ROOT="$(cd `dirname "${BASH_SOURCE}"`/../..; pwd)"
 ENV_CODE=${1:-${ENV_CODE}}
+LE_EMAIL_ADDRESS=${2:-${LE_EMAIL_ADDRESS}}
 
-if [[ -z "$ENV_CODE" ]]
-  then
-    echo "Environment Code value not supplied"
-    exit 1
-fi
+[[ -z "$ENV_CODE" ]] && { echo "Environment Code value not supplied"; exit 1; }
+[[ -z "$LE_EMAIL_ADDRESS" ]] && { echo "Let's Encrypt e-mail address (LE_EMAIL_ADDRESS) not specified"; exit 1; }
 
 set -a
+set -e
 ENV_NAME=${ENV_NAME:-"stac-${ENV_CODE}"}
 MONITORING_RESOURCE_GROUP=${MONITORING_RESOURCE_GROUP:-"${ENV_CODE}-monitoring-rg"}
 VNET_RESOURCE_GROUP=${VNET_RESOURCE_GROUP:-"${ENV_CODE}-vnet-rg"}
@@ -21,18 +20,10 @@ PROCESSING_RESOURCE_GROUP=${PROCESSING_RESOURCE_GROUP:-"${ENV_CODE}-processing-r
 UAMI=${UAMI:-"${ENV_CODE}-stacaks-mi"}
 
 AKS_NAMESPACE=${AKS_NAMESPACE:-"pgstac"}
+AKS_INGRESS_NAMESPACE=${AKS_INGRESS_NAMESPACE:-"ingress"}
 ENV_LABEL=${ENV_LABEL:-"stacpool"} # aks agent pool name to deploy kubectl deployment yaml files
 AKS_SERVICE_ACCOUNT_NAME=${AKS_SERVICE_ACCOUNT_NAME:-'stac-svc-acct'}
 FEDERATED_IDENTITY_NAME="stacaksfederatedidentity"
-
-
-APIM_SERVICE_NAME=$(az apim list --resource-group $PROCESSING_RESOURCE_GROUP --query "[0].name" -o tsv)
-
-APIM_STAC_LOADBALANCER_URL=$(az apim api list --resource-group $PROCESSING_RESOURCE_GROUP \
-    --service-name $APIM_SERVICE_NAME --filter-display-name fast-stac-api \
-    | jq -r ".[0].serviceUrl")
-
-LOADBALANCER_IP=$(echo "$APIM_STAC_LOADBALANCER_URL" | awk -F/ '{print $3}' | awk -F: '{print $1}')
 
 SUBSCRIPTION=$(az account show --query id -o tsv)
 AZURE_APP_INSIGHTS=$(az resource list -g $MONITORING_RESOURCE_GROUP --resource-type "Microsoft.Insights/components" \
@@ -55,13 +46,20 @@ DATA_STORAGE_ACCOUNT_CONNECTION_STRING=$(az storage account show-connection-stri
     --name $DATA_STORAGE_ACCOUNT_NAME \
     | jq -r ".connectionString")
 
+DATA_STORAGE_ACCOUNT_BLOB_ENDPOINT=$(az storage account show -n $DATA_STORAGE_ACCOUNT_NAME \
+    --query primaryEndpoints.blob -otsv)
+DATA_STORAGE_ACCOUNT_BLOB_DOMAIN=${DATA_STORAGE_ACCOUNT_BLOB_ENDPOINT#https://}
+DATA_STORAGE_ACCOUNT_BLOB_DOMAIN=${DATA_STORAGE_ACCOUNT_BLOB_DOMAIN%%/*}
+
 AKS_RESOURCE_GROUP=${AKS_RESOURCE_GROUP:-${PROCESSING_RESOURCE_GROUP}}
-AKS_CLUSTER_NAME=$(az aks list -g ${PROCESSING_RESOURCE_GROUP} \
+AKS_CLUSTER_NAME=$(az aks list -g ${AKS_RESOURCE_GROUP} \
     --query "[?tags.type && tags.type == 'k8s'].name" -otsv)
 ACR_DNS=$(az acr list -g ${PROCESSING_RESOURCE_GROUP} \
     --query "[?tags.environment && tags.environment == '$ENV_NAME'].loginServer" -otsv)
-AKS_OIDC_ISSUER="$(az aks show --resource-group ${PROCESSING_RESOURCE_GROUP} \
+AKS_OIDC_ISSUER="$(az aks show --resource-group ${AKS_RESOURCE_GROUP} \
     --name ${AKS_CLUSTER_NAME} --query "oidcIssuerProfile.issuerUrl" -o tsv)"
+AKS_POD_CIDR="$(az aks show -g $AKS_RESOURCE_GROUP -n $AKS_CLUSTER_NAME \
+    --query networkProfile.podCidr -o tsv)"
 
 USER_ASSIGNED_CLIENT_ID="$(az identity show -g ${PROCESSING_RESOURCE_GROUP} \
     --name $UAMI --query 'clientId' -o tsv)"
@@ -72,7 +70,8 @@ az identity federated-credential create --name ${FEDERATED_IDENTITY_NAME} \
     --identity-name $UAMI \
     --resource-group ${PROCESSING_RESOURCE_GROUP} \
     --issuer ${AKS_OIDC_ISSUER} \
-    --subject system:serviceaccount:${AKS_NAMESPACE}:${AKS_SERVICE_ACCOUNT_NAME}
+    --subject system:serviceaccount:${AKS_NAMESPACE}:${AKS_SERVICE_ACCOUNT_NAME} \
+    -o none
 
 SERVICE_BUS_NAMESPACE=$(az servicebus namespace list \
     -g ${DATA_RESOURCE_GROUP} --query "[?tags.environment && tags.environment == '$ENV_NAME'].name" -otsv)
@@ -117,7 +116,6 @@ PGPASSWORD_SECRET_NAME=${PGPASSWORD_SECRET_NAME:-"PGAdminLoginPass"}
 PGPASSWORD=$(az keyvault secret show --vault-name $KEY_VAULT_NAME --name $PGPASSWORD_SECRET_NAME --query value -o tsv)
 PGDATABASE=${PGDATABASE:-"postgres"}
 PGPORT=${PGPORT:-"5432"}
-LB_PRIVATE_IP=${LB_PRIVATE_IP:-"10.6.3.254"}
 
 STACIFY_STORAGE_CONTAINER_NAME=${STACIFY_STORAGE_CONTAINER_NAME:-"stacify"}
 STACIFY_SERVICE_BUS_TOPIC_NAME=${STACIFY_SERVICE_BUS_TOPIC_NAME:-"stacifytopic"}
@@ -142,17 +140,24 @@ STACCOLLECTION_SERVICE_BUS_CONNECTION_STRING=$(az servicebus topic authorization
     --name ${STACCOLLECTION_SERVICE_BUS_AUTH_POLICY_NAME} \
     --query "primaryConnectionString" -otsv)
 
+INGRESS_PUBLIC_IP_ADDR=$(az network public-ip show -g $PROCESSING_RESOURCE_GROUP \
+    -n ${ENV_CODE}-stac-ingress-public-ip --query ipAddress -o tsv)
+INGRESS_FQDN=$(az network public-ip show -g $PROCESSING_RESOURCE_GROUP -n ${ENV_CODE}-stac-ingress-public-ip \
+    --query dnsSettings.fqdn -o tsv)
+DNS_LABEL_NAME=${INGRESS_FQDN%%.*}
 
 set +a
-export -p
 
 echo 'enabling POSTGIS,BTREE_GIST in postgres'
 az postgres flexible-server \
     parameter set \
     --resource-group $DATA_RESOURCE_GROUP --server-name $PGHOSTONLY \
-    --subscription $SUBSCRIPTION --name azure.extensions --value POSTGIS,BTREE_GIST
+    --subscription $SUBSCRIPTION --name azure.extensions --value POSTGIS,BTREE_GIST \
+    -o none
 
-az aks get-credentials --resource-group ${AKS_RESOURCE_GROUP} --name ${AKS_CLUSTER_NAME} --context ${AKS_CLUSTER_NAME} --overwrite-existing
+az aks get-credentials --admin --resource-group ${AKS_RESOURCE_GROUP} \
+  --name ${AKS_CLUSTER_NAME} --context ${AKS_CLUSTER_NAME} --overwrite-existing \
+  -o none
 kubectl config set-context ${AKS_CLUSTER_NAME}
 
 NS=$(kubectl get namespace $AKS_NAMESPACE --ignore-not-found);
@@ -164,40 +169,340 @@ else
 fi;
 
 echo "Install KEDA"
-kubectl apply -f https://github.com/kedacore/keda/releases/download/v2.9.1/keda-2.9.1.yaml
+helm repo add kedacore https://kedacore.github.io/charts || true
+helm repo update
+[[ -z "$(kubectl get namespace keda --ignore-not-found)" ]] && kubectl create namespace keda
+helm upgrade --install keda kedacore/keda --namespace keda
 
-echo "Deploying chart to Kubernetes Cluster"
+# Deploy a dummy workload to work around issue https://github.com/kedacore/keda/issues/4224
+cat <<"EOF" | kubectl apply -n keda -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dummy-workload
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: dummy-workload
+  template:
+    metadata:
+      labels:
+        app: dummy-workload
+    spec:
+      containers:
+      - name: dummy
+        image: busybox
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: dummy-workload
+spec:
+  scaleTargetRef:
+    name: dummy-workload
+  minReplicaCount: 0
+  maxReplicaCount: 1
+  triggers:
+  - type: cron
+    metadata:
+      timezone: Etc/UTC 
+      start: 30 * * * *
+      end: 45 * * * *
+      desiredReplicas: "0"
+EOF
+kubectl -n keda wait --for=condition=Ready ScaledObject/dummy-workload --timeout=3m
+sleep 10
 
-helm install stac-scaler ${PRJ_ROOT}/deploy/helm/stac-scaler \
+echo "Deploying stac-scaler chart to Kubernetes Cluster"
+
+helm upgrade --install stac-scaler ${PRJ_ROOT}/deploy/helm/stac-scaler \
+    --namespace ${AKS_NAMESPACE} \
+    --create-namespace \
     --set envCode=${ENV_CODE} \
     --set repository=${ACR_DNS} \
     --set userAssignedClientId=${USER_ASSIGNED_CLIENT_ID} \
     --set serviceAccountName=${AKS_SERVICE_ACCOUNT_NAME} \
     --set keyVaultName=${KEY_VAULT_NAME} \
     --set tenantId=${IDENTITY_TENANT} \
-    --set processors.staccollection.topicNamespace=${SERVICE_BUS_NAMESPACE} \
     --set processors.staccollection.env.DATA_STORAGE_ACCOUNT_NAME=${DATA_STORAGE_ACCOUNT_NAME} \
     --set processors.staccollection.env.STACCOLLECTION_STORAGE_CONTAINER_NAME=${STACCOLLECTION_STORAGE_CONTAINER_NAME} \
     --set processors.staccollection.env.PGHOST=${PGHOST} \
     --set processors.staccollection.env.PGUSER=${PGUSER} \
     --set processors.staccollection.env.PGDATABASE=${PGDATABASE} \
-    --set processors.staceventconsumer.namespace=${SERVICE_BUS_NAMESPACE} \
     --set processors.staceventconsumer.env.DATA_STORAGE_ACCOUNT_NAME=${DATA_STORAGE_ACCOUNT_NAME} \
     --set processors.staceventconsumer.env.GENERATED_STAC_STORAGE_CONTAINER_NAME=${GENERATED_STAC_STORAGE_CONTAINER_NAME} \
     --set processors.staceventconsumer.env.DATA_STORAGE_PGSTAC_CONTAINER_NAME=${DATA_STORAGE_PGSTAC_CONTAINER_NAME} \
     --set processors.staceventconsumer.env.PGHOST=${PGHOST} \
     --set processors.staceventconsumer.env.PGUSER=${PGUSER} \
     --set processors.staceventconsumer.env.PGDATABASE=${PGDATABASE} \
-    --set processors.generatestacjson.namespace=${SERVICE_BUS_NAMESPACE} \
     --set processors.generatestacjson.env.DATA_STORAGE_ACCOUNT_NAME=${DATA_STORAGE_ACCOUNT_NAME} \
     --set processors.generatestacjson.env.STACIFY_STORAGE_CONTAINER_NAME=${STACIFY_STORAGE_CONTAINER_NAME} \
     --set processors.generatestacjson.env.GENERATED_STAC_STORAGE_CONTAINER_NAME=${GENERATED_STAC_STORAGE_CONTAINER_NAME} \
     --set processors.generatestacjson.env.DATA_STORAGE_PGSTAC_CONTAINER_NAME=${DATA_STORAGE_PGSTAC_CONTAINER_NAME} \
     --set processors.generatestacjson.env.STAC_METADATA_TYPE_NAME=${STAC_METADATA_TYPE_NAME} \
     --set stacfastapi.image.repository=${ACR_DNS} \
-    --set stacfastapi.privateIp=${LOADBALANCER_IP} \
     --set stacfastapi.env.POSTGRES_HOST_READER=${PGHOST} \
     --set stacfastapi.env.POSTGRES_HOST_WRITER=${PGHOST} \
     --set stacfastapi.env.POSTGRES_USER=${PGUSER} \
     --set stacfastapi.env.PGUSER=${PGUSER} \
-    --set stacfastapi.env.PGHOST=${PGHOST}    
+    --set stacfastapi.env.PGHOST=${PGHOST} \
+    --set stacfastapi.blobStoreEndpoint=${DATA_STORAGE_ACCOUNT_BLOB_ENDPOINT} \
+    --set stacfastapi.hostname=${INGRESS_FQDN} \
+    --set stacfastapi.clusterIssuer=letsencrypt
+
+echo "Deploying stac-browser chart to Kubernetes Cluster"
+
+helm upgrade --install stac-browser ${PRJ_ROOT}/deploy/helm/stac-browser \
+    --namespace ${AKS_NAMESPACE} \
+    --create-namespace \
+    --set envCode=${ENV_CODE} \
+    --set repository=${ACR_DNS} \
+    --set hostname=${INGRESS_FQDN} \
+    --set clusterIssuer=letsencrypt
+
+# Add helm repos for the nginx ingress controller and cert-manager
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+
+# Install the cert-manager Helm chart (for letsencrypt certificates)
+echo "Installing cert-manager"
+kubectl create namespace $AKS_INGRESS_NAMESPACE
+kubectl label namespace $AKS_INGRESS_NAMESPACE cert-manager.io/disable-validation=true
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --create-namespace \
+  --namespace $AKS_INGRESS_NAMESPACE \
+  --set installCRDs=true \
+  --set nodeSelector."kubernetes\.io/os"=linux
+
+# Create a ClusterIssuer to issue certificates from Lets Encrypt
+cat <<EOF | kubectl apply -n $AKS_INGRESS_NAMESPACE -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: $LE_EMAIL_ADDRESS
+    privateKeySecretRef:
+      name: letsencrypt-private-key
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+          podTemplate:
+            spec:
+              nodeSelector:
+                "kubernetes.io/os": linux
+EOF
+
+
+# Wait for the cert-manager pods to be ready
+echo "Waiting for cert-manager deployment to be ready..."
+kubectl -n $AKS_INGRESS_NAMESPACE wait --timeout=5m \
+    --for=condition=Ready pod \
+    --selector=app.kubernetes.io/name=cert-manager
+
+# Create a long-lived SAS token for reading from the storage account and store it in keyvault.
+# The nginx ingress controller will use this for accessing the storage account via proxy
+# by appending the SAS token to the URL when sending to the backend server.
+SAS_TOKEN=$(az storage account generate-sas \
+    --resource-types sco --services b --permissions flpr \
+    --expiry "2037-12-31T23:59Z" \
+    --https-only \
+    --account-name $DATA_STORAGE_ACCOUNT_NAME \
+    --account-key $DATA_STORAGE_ACCOUNT_KEY \
+    -otsv)
+az keyvault secret set \
+    --vault-name $KEY_VAULT_NAME \
+    --name StorageAccountReadSASToken \
+    --value $SAS_TOKEN \
+    -o none
+
+##
+## Install the nginx ingress controller, configured with the CSI secret store
+## driver to access the Azure Storage Account SAS token.
+##
+
+# Create a secret provider to access the Azure Storage Account SAS token
+cat <<EOF | kubectl apply -n $AKS_INGRESS_NAMESPACE -f -
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: k8s-nginx-ingress-secrets
+spec:
+  provider: azure
+  secretObjects:
+  - secretName: azure-secrets
+    type: Opaque
+    data:
+    - key: StorageAccountReadSASToken
+      objectName: StorageAccountReadSASToken
+  parameters:
+    usePodIdentity: "false"
+    useVMManagedIdentity: "false"
+    # The client ID of the user-assigned managed identity or application that is
+    # used for workload identity, and to access the keyvault.
+    clientID: $USER_ASSIGNED_CLIENT_ID
+    keyvaultName: $KEY_VAULT_NAME
+    tenantID: $IDENTITY_TENANT
+    cloudName: $(az cloud show --query name -otsv)
+    objects:  |
+      array:
+        - |
+          objectName: StorageAccountReadSASToken
+          objectType: secret
+EOF
+
+RELEASE_NAME=ingress-nginx
+
+# Create the credential to allow the ingress controller to use the managed identity
+# to access secrets in the keyvault.
+echo "Creating a federated credential for the ingress controller to access the managed identity $UAMI"
+az identity federated-credential create --name nginx-ingress-access-$AKS_NAME \
+    --identity-name $UAMI \
+    --resource-group $PROCESSING_RESOURCE_GROUP \
+    --issuer $AKS_OIDC_ISSUER \
+    --subject system:serviceaccount:$AKS_INGRESS_NAMESPACE:$RELEASE_NAME \
+    -o none
+
+helm upgrade --install $RELEASE_NAME ingress-nginx/ingress-nginx \
+    --namespace $AKS_INGRESS_NAMESPACE \
+    --create-namespace \
+    --set controller.replicaCount=2 \
+    --set controller.nodeSelector."kubernetes\.io/os"=linux \
+    --set defaultBackend.nodeSelector."kubernetes\.io/os"=linux \
+    --set serviceAccount.annotations."azure\.workload\.identity/client-id"=$USER_ASSIGNED_CLIENT_ID \
+    --set controller.config.proxy-buffer-size=32k \
+    --set controller.config.main-snippet="env STORAGE_SAS_TOKEN;" \
+    --set controller.config.http-snippet="geo \$internal_user { $AKS_POD_CIDR 1; }" \
+    --set controller.admissionWebhooks.patch.nodeSelector."kubernetes\.io/os"=linux \
+    --set controller.service.externalTrafficPolicy=Local \
+    --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-resource-group"="$PROCESSING_RESOURCE_GROUP" \
+    --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-dns-label-name"="$DNS_LABEL_NAME" \
+    --set controller.service.loadBalancerIP=$INGRESS_PUBLIC_IP_ADDR \
+    --set controller.image.repository=mcr.microsoft.com/oss/kubernetes/ingress/nginx-ingress-controller \
+    --set controller.image.tag=v1.7.0-3 \
+    --set controller.image.digest=sha256:29ad700988b2dd3e7b9b130c2625f24d5b5eae7420e3dfd6dee579a730ecbb1c \
+    --set "controller.extraVolumeMounts[0].name=secrets-store-inline" \
+    --set "controller.extraVolumeMounts[0].mountPath=/mnt/secrets-store" \
+    --set "controller.extraVolumeMounts[0].readOnly=true" \
+    --set "controller.extraVolumes[0].name=secrets-store-inline" \
+    --set "controller.extraVolumes[0].csi.driver=secrets-store.csi.k8s.io" \
+    --set "controller.extraVolumes[0].csi.readOnly=true" \
+    --set "controller.extraVolumes[0].csi.volumeAttributes.secretProviderClass=k8s-nginx-ingress-secrets" \
+    --set "controller.extraEnvs[0].name=STORAGE_SAS_TOKEN" \
+    --set "controller.extraEnvs[0].valueFrom.secretKeyRef.name=azure-secrets" \
+    --set "controller.extraEnvs[0].valueFrom.secretKeyRef.key=StorageAccountReadSASToken"
+
+# Helm creates the service account, but there's no way to add the label we need to it.
+# Add that manually after the fact.
+kubectl label -n $AKS_INGRESS_NAMESPACE sa/$RELEASE_NAME azure.workload.identity/use="true"
+
+# Wait for the ingress controller to be ready
+echo "Waiting for ingress controller to be ready..."
+kubectl -n $AKS_INGRESS_NAMESPACE wait --timeout=5m \
+    --for=condition=Ready pod \
+    --selector=app.kubernetes.io/name=$RELEASE_NAME
+
+# Deploy the ingress for the blob store proxy that forwards requests
+# to storage with a SAS token appended.
+cat <<EOF | kubectl -n $AKS_NAMESPACE apply -f -
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: blobstore-proxy
+spec:
+  type: ExternalName
+  externalName: $DATA_STORAGE_ACCOUNT_BLOB_DOMAIN
+  ports:
+  - port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: blobstore-proxy
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /\$1
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/upstream-vhost: "$DATA_STORAGE_ACCOUNT_BLOB_DOMAIN"
+    # Rewrite URI to include SAS token (note, the query separator has to be
+    # in the rewrite statement, and not as part of the SAS token)
+    # TODO: handle URLs that might already have a query string
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_cache off;
+      rewrite (.*) \$1?\$storage_sas_token;
+    # Reads the SAS token from the STORAGE_SAS_TOKEN environment variable and
+    # sets as an nginx variable so we can use it in the rewrite statement. Note
+    # that this relies on the server configmap containing a main-snippet with an
+    # "env STORAGE_SAS_TOKEN" statement to ensure nginx inherits that env variable
+    # from its parent.
+    nginx.ingress.kubernetes.io/server-snippet: |
+      set_by_lua_block \$storage_sas_token { return os.getenv("STORAGE_SAS_TOKEN") }
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - $INGRESS_FQDN
+    secretName: stac-certificate
+  rules:
+  - host: $INGRESS_FQDN
+    http:
+      paths:
+      - path: /blobstore/(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: blobstore-proxy
+            port:
+              number: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: stac-browser
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /\$2
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - $INGRESS_FQDN
+    secretName: stac-certificate
+  rules:
+  - host: $INGRESS_FQDN
+    http:
+      paths:
+      - path: /browser(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: stac-browser
+            port:
+              number: 8082
+EOF
+
+# Deploy the auth proxy if selected
+[[ -n "$SECURE_STAC_ENDPOINTS" ]] && $PRJ_ROOT/deploy/scripts/secure-stac-endpoints.sh
+
+cat <<EOF
+
+
+
+**** The STAC API is available at: https://$INGRESS_FQDN/api/
+The TLS certificate may not have been issued yet, so you may see a warning in your browser.
+If you wish to wait, you can run the following command to wait until the certificate is ready:
+  kubectl -n $AKS_NAMESPACE wait --timeout=10m --for=condition=Ready certificate stac-certificate
+
+If this command times out, then it is possible there was an error with cert generation. You can
+inspect the cert-manager logs to see if there was an error:
+  kubectl -n $AKS_INGRESS_NAMESPACE logs -l app=cert-manager
+EOF

--- a/deploy/scripts/install.sh
+++ b/deploy/scripts/install.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-set -ex
+set -e
 PRJ_ROOT="$(cd `dirname "${BASH_SOURCE}"`/../..; pwd)"
 
 # Setup required parameters
@@ -36,9 +36,10 @@ DEPLOYMENT_NAME=${6:-${DEPLOYMENT_NAME:-"${ENV_TAG}-deploy"}}
 CONFIGURE_POD_IDENTITY=${7:-${CONFIGURE_POD_IDENTITY:-"false"}}
 ENABLE_PUBLIC_ACCESS=${8:-${ENABLE_PUBLIC_ACCESS:-"false"}}
 USER_OBJ_ID=${USER_OBJ_ID:-"$(az ad signed-in-user show --query id --output tsv 2> /dev/null || echo '')"}
-LB_PRIVATE_IP=${LB_PRIVATE_IP:-"10.6.3.254"}
-APIM_PLATFORM_VERSION=${APIM_PLATFORM_VERSION:-'stv2'}
 POSTGRES_PRIVATE_ENDPOINT_DISABLED=${POSTGRES_PRIVATE_ENDPOINT_DISABLED:-false}
+if [[ -n "$DNS_PREFIX" ]]; then
+  DNS_ARG="ingressPublicIPDnsPrefixVar=$DNS_PREFIX"
+fi
 
 if [[ -z "$USER_OBJ_ID" ]]
   then
@@ -46,7 +47,20 @@ if [[ -z "$USER_OBJ_ID" ]]
     echo "To get USER_OBJ_ID, run 'az ad signed-in-user show --query id --output tsv'"
 fi
 
-az feature register --namespace "Microsoft.ContainerService" --name "EnableWorkloadIdentityPreview"
+# Register the workload identity feature, and wait for it to be registered.
+if [[ $(az feature show --namespace "Microsoft.ContainerService" --name "EnableWorkloadIdentityPreview" --query properties.state -otsv) != "Registered" ]]; then
+  echo "Registering workload identity preview with AKS."
+  az feature register --namespace "Microsoft.ContainerService" --name "EnableWorkloadIdentityPreview"
+  workload_identity_registered=true
+fi
+while [[ $(az feature show --namespace "Microsoft.ContainerService" --name "EnableWorkloadIdentityPreview" --query properties.state -otsv) != "Registered" ]]; do
+  echo "Waiting for the workload identity preview feature to be registered."
+  sleep 10
+done
+# If we actually registered the feature, then we need to re-register the provider to get the change to propagate
+if [[ $workload_identity_registered ]]; then
+  az provider register --namespace "Microsoft.ContainerService"
+fi
 
 # Captures the Azure cloud endpoints/suffixes
 az cloud show -o json > $PRJ_ROOT/deploy/cloud_endpoints.json
@@ -54,7 +68,7 @@ az cloud show -o json > $PRJ_ROOT/deploy/cloud_endpoints.json
 # Minimum required version of Kubernetes is 1.22.0. We assume all regions have atleast 1.22.0 or later version
 AKS_VERSION=$(az aks get-versions -l $LOCATION --query 'orchestrators[?!isPreview].orchestratorVersion' -otsv | sort -rV | head -n1)
 
-DEPLOYMENT_SCRIPT="az deployment sub create -l $LOCATION -n $DEPLOYMENT_NAME \
+DEPLOYMENT_SCRIPT="az deployment sub create -o none -l $LOCATION -n $DEPLOYMENT_NAME \
     -f $PRJ_ROOT/deploy/bicep/main.bicep \
     -p \
     location=$LOCATION \
@@ -63,10 +77,8 @@ DEPLOYMENT_SCRIPT="az deployment sub create -l $LOCATION -n $DEPLOYMENT_NAME \
     kubernetesVersion=$AKS_VERSION \
     jumpboxAdminUsername=$JUMPBOX_USERNAME \
     jumpboxAdminPassword=$JUMPBOX_PASSWORD \
-    loadBalancerPrivateIP=$LB_PRIVATE_IP \
     enablePublicAccess=$ENABLE_PUBLIC_ACCESS \
-    apimPlatformVersion=$APIM_PLATFORM_VERSION \
     privateEndpointDisabled=$POSTGRES_PRIVATE_ENDPOINT_DISABLED \
-    owner_aad_object_id=$USER_OBJ_ID"
+    owner_aad_object_id=$USER_OBJ_ID $DNS_ARG"
 
 $DEPLOYMENT_SCRIPT

--- a/deploy/scripts/secure-keyvault.sh
+++ b/deploy/scripts/secure-keyvault.sh
@@ -27,5 +27,5 @@ echo "Getting Keyvault name"
 KEYVAULT_NAME=$(az keyvault list --resource-group ${DATA_RESOURCE_GROUP} --query '[0].name' -o tsv)
 
 echo "Securing Keyvault to be accessed only on jumpbox subnet"
-az keyvault network-rule add --name ${KEYVAULT_NAME} --resource-group ${DATA_RESOURCE_GROUP} --subnet ${JUMPBOX_SUBNET_ID}
-az keyvault update --name ${KEYVAULT_NAME} --resource-group ${DATA_RESOURCE_GROUP} --set properties.networkAcls.defaultAction=Deny
+az keyvault network-rule add --name ${KEYVAULT_NAME} --resource-group ${DATA_RESOURCE_GROUP} --subnet ${JUMPBOX_SUBNET_ID} -o none
+az keyvault update --name ${KEYVAULT_NAME} --resource-group ${DATA_RESOURCE_GROUP} --set properties.networkAcls.defaultAction=Deny -o none

--- a/deploy/scripts/secure-stac-endpoints.sh
+++ b/deploy/scripts/secure-stac-endpoints.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+PRJ_ROOT="$(cd `dirname "${BASH_SOURCE}"`/../..; pwd)"
+ENV_CODE=${1:-${ENV_CODE}}
+AKS_NAMESPACE=${AKS_NAMESPACE:-"pgstac"}
+AKS_INGRESS_NAMESPACE=${AKS_INGRESS_NAMESPACE:-"ingress"}
+
+[[ -z "$ENV_CODE" ]] && { echo "Environment Code value not supplied"; exit 1; }
+
+set -a
+set -e
+echo "Retrieving required properties from Azure resources."
+PROCESSING_RESOURCE_GROUP=${PROCESSING_RESOURCE_GROUP:-"${ENV_CODE}-processing-rg"}
+AAD_ENDPOINT=$(az cloud show --query endpoints.activeDirectory -otsv)
+TENANT_ID=$(az account show --query tenantId -otsv)
+
+# Retrieve the public IP address we created in the deployment
+FQDN=$(az network public-ip show -g $PROCESSING_RESOURCE_GROUP \
+  -n ${ENV_CODE}-stac-ingress-public-ip --query dnsSettings.fqdn -o tsv)
+DNS_DOMAIN=${FQDN#*.}
+
+# Create an Azure AD application to perform authentication on the STAC endpoints
+echo "Creating Azure AD application to secure the STAC endpoints"
+APP_ID=$(az ad app create \
+  --display-name "STAC Endpoints for $ENV_CODE" \
+  --sign-in-audience AzureADMyOrg \
+  --web-redirect-uris "https://$FQDN/oauth2/callback" \
+  --optional-claims @$PRJ_ROOT/deploy/data/claims.json \
+  --required-resource-accesses @$PRJ_ROOT/deploy/data/resource_access.json \
+  --app-roles @$PRJ_ROOT/deploy/data/roles.json \
+  --query "appId" -otsv)
+# Generate a password for the app
+APP_PW=$(az ad app credential reset \
+  --id $APP_ID \
+  --append \
+  --display-name "oauth2-proxy access for STAC endpoints on $(az account show --query name -otsv)" \
+  --query "password" -otsv)
+
+helm repo add oauth2-proxy https://oauth2-proxy.github.io/manifests || true
+helm repo update
+
+# Install the oauth2-proxy Helm chart
+echo "Installing the oauth2-proxy Helm chart"
+AKS_RESOURCE_GROUP=${AKS_RESOURCE_GROUP:-${PROCESSING_RESOURCE_GROUP}}
+AKS_CLUSTER_NAME=$(az aks list -g ${AKS_RESOURCE_GROUP} --query "[?tags.type && tags.type == 'k8s'].name" -otsv)
+AKS_ISSUER_URL=$(az aks show --resource-group $AKS_RESOURCE_GROUP --name $AKS_CLUSTER_NAME --query oidcIssuerProfile.issuerUrl -otsv)
+OAUTH_PROXY_VALUES_FILE=$(mktemp -t oauth2-proxy-values)
+trap 'rm -f -- "$OAUTH_PROXY_VALUES_FILE"' EXIT
+cat > $OAUTH_PROXY_VALUES_FILE <<EOF
+replicaCount: 2
+config:
+  clientID: $APP_ID
+  clientSecret: $APP_PW
+  cookieSecret: $(openssl rand -base64 32 | tr -- '+/' '-_')
+
+ingress:
+  enabled: true
+  className: nginx
+  path: /oauth2
+  pathType: Prefix
+  hosts:
+    - $FQDN
+  tls:
+    - hosts:
+        - $FQDN
+      secretName: stac-certificate
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+
+extraArgs:
+  provider: oidc
+  oidc-issuer-url: $AAD_ENDPOINT/$TENANT_ID/v2.0
+  # Use the next two lines instead to support multi-tenant authentication.
+  # Note that if a tenant does not include an e-mail address in the payload
+  # returned by authentication, then oauth2-proxy will fail to authenticate.
+  # oidc-issuer-url: $AAD_ENDPOINT/common/v2.0
+  # insecure-oidc-skip-issuer-verification: true
+  code-challenge-method: S256
+  # AAD doesn't always return an e-mail address in the email claim. Use
+  # the preferred_username field as it seems to be present in most cases.
+  # If this claim is missing, authentication will fail.
+  oidc-email-claim: preferred_username
+  # Look for "groups" in the roles claim, in case we assigned app roles
+  # to the user.
+  oidc-groups-claim: roles
+  cookie-refresh: 10m
+  cookie-expire: 15m
+  cookie-domain: .$DNS_DOMAIN
+  # Pass authentication information to the nginx ingress controller
+  pass-access-token: true
+  set-xauthrequest: true
+  set-authorization-header: true
+  silence-ping-logging: true
+  whitelist-domain: .$FQDN
+  scope: openid email profile
+  # Allow authentication from a JWT Bearer token. Only token issued
+  # by the issuers listed in oidc-issuer-url and extra-jwt-issuers will
+  # be trusted. The aud claim must also match the right-hand side of the
+  # pair in extra-jwt-issuers. In this case, we're trusting tokens issued
+  # by the AKS cluster and the Azure AD app we created above.
+  skip-jwt-bearer-tokens: true
+  extra-jwt-issuers: "$AKS_ISSUER_URL=$AKS_ISSUER_URL,$AAD_ENDPOINT/$TENANT_ID/v2.0=$APP_ID"
+  show-debug-on-error: true
+  ##
+  ## Authorization limits. You can limit authorization to certain groups
+  ## and/or e-mail domains.
+  ##
+  # Change this if you want to limit access to certain e-mail domains.
+  email-domain: "*"
+  # Uncomment to limit access to certain groups
+  #allowed-group: "STAC.Read,STAC.Write"
+
+service:
+  portNumber: 4180
+
+nodeSelector:
+  kubernetes.io/os: linux
+EOF
+
+helm upgrade --install oauth2-proxy oauth2-proxy/oauth2-proxy \
+    --create-namespace \
+    --namespace $AKS_INGRESS_NAMESPACE \
+    -f $OAUTH_PROXY_VALUES_FILE
+rm -f $OAUTH_PROXY_VALUES_FILE
+
+echo "Waiting for oauth2-proxy deployment to be ready"
+kubectl -n $AKS_INGRESS_NAMESPACE wait --for=condition=Ready pod \
+  -l app.kubernetes.io/name=oauth2-proxy --timeout=5m
+
+# Apply annotations to enable auth on the STAC endpoints
+kubectl -n $AKS_NAMESPACE annotate ingress stac-browser \
+    nginx.ingress.kubernetes.io/auth-url='https://$host/oauth2/auth' \
+    nginx.ingress.kubernetes.io/auth-signin='https://$host/oauth2/start?rd=$escaped_request_uri'
+kubectl -n $AKS_NAMESPACE annotate ingress fast-stac-api \
+    nginx.ingress.kubernetes.io/auth-url='https://$host/oauth2/auth' \
+    nginx.ingress.kubernetes.io/auth-signin='https://$host/oauth2/start?rd=$escaped_request_uri'
+kubectl -n $AKS_NAMESPACE annotate ingress blobstore-proxy \
+    nginx.ingress.kubernetes.io/auth-url='https://$host/oauth2/auth' \
+    nginx.ingress.kubernetes.io/auth-signin='https://$host/oauth2/start?rd=$escaped_request_uri'
+kubectl -n $AKS_NAMESPACE annotate ingress blobstore-proxy nginx.ingress.kubernetes.io/auth-snippet='
+  # Allow internal requests to bypass auth. $internal_user is set up when the
+  # chart is deployed using the main-snippet value in the configmap. The variable
+  # is true if the caller IP is in the k8s cluster pod cidr range.
+  if ($internal_user) {
+    return 200;
+  }'

--- a/deploy/scripts/setup.sh
+++ b/deploy/scripts/setup.sh
@@ -6,39 +6,25 @@
 PRJ_ROOT="$(cd `dirname "${BASH_SOURCE}"`/../..; pwd)"
 ENV_CODE=${1:-${ENV_CODE}}
 LOCATION=${2:-${LOCATION}}
-JUMPBOX_PASSWORD=${3:-${JUMPBOX_PASSWORD}}
-JUMPBOX_USERNAME=${4:-${JUMPBOX_USERNAME:-"adminuser"}}
-LB_PRIVATE_IP=${5:-${LB_PRIVATE_IP:-"10.6.3.254"}}
+LE_EMAIL_ADDRESS=${3:-${LE_EMAIL_ADDRESS}}
+JUMPBOX_PASSWORD=${4:-${JUMPBOX_PASSWORD}}
+JUMPBOX_USERNAME=${5:-${JUMPBOX_USERNAME:-"adminuser"}}
 
 set -e
 
-if [[ -z "$ENV_CODE" ]]
-  then
-    echo "Environment Code value not supplied"
-    exit 1
-fi
-
-if [[ -z "$LOCATION" ]]
-  then
-    echo "Location value not supplied"
-    exit 1
-fi
-
-if [[ -z "$JUMPBOX_PASSWORD" ]]
-  then
-    echo "Jumpbox Password not supplied"
-    exit 1
-fi
+[[ -z "$ENV_CODE" ]] && { echo "Environment Code value not supplied"; exit 1; }
+[[ -z "$LOCATION" ]] && { echo "Location value not supplied"; exit 1; }
+[[ -z "$JUMPBOX_PASSWORD" ]] && { echo "Jumpbox Password not supplied"; exit 1; }
+[[ -z "$LE_EMAIL_ADDRESS" ]] && { echo "Let's Encrypt e-mail address (LE_EMAIL_ADDRESS) not specified"; exit 1; }
 
 echo "Performing bicep template deployment"
-LB_PRIVATE_IP=$LB_PRIVATE_IP \
 $PRJ_ROOT/deploy/scripts/install.sh "$ENV_CODE" "$LOCATION" "$JUMPBOX_PASSWORD" "$JUMPBOX_USERNAME"
 
 echo "Building containers and Deploying to Infra"
 $PRJ_ROOT/deploy/scripts/build.sh "$ENV_CODE"
 
 echo "Performing configuration and Deploying Apps"
-LB_PRIVATE_IP=$LB_PRIVATE_IP \
+LE_EMAIL_ADDRESS="$LE_EMAIL_ADDRESS" \
 $PRJ_ROOT/deploy/scripts/configure.sh "$ENV_CODE"
 
 echo "Securing Keyvault access"

--- a/docs/cataloging-sample-data.md
+++ b/docs/cataloging-sample-data.md
@@ -1,15 +1,23 @@
 # Cataloging the sample data
 
-Sample data is hosted in a Storage Account that is available for anyone to download without authentication. The data in this Storage Account can be used to run through the cataloging process and then queries through the STAC API.
+Sample data is hosted in a Storage Account that is available for anyone to
+download without authentication. The data in this Storage Account can be used
+to run through the cataloging process and then queries through the STAC API.
 
-The steps below walk you through the creation of STAC Collection and STAC Item. When following the steps below, make sure the order of execution is followed as the sequence of upload is critical to the cataloging process.
+The steps below walk you through the creation of STAC Collection and STAC
+Item. When following the steps below, make sure the order of execution is
+followed as the sequence of upload is critical to the cataloging process.
 
 ## Steps to Catalog Sample data
 
-1. First step in the process is the creation of the [STAC collection](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md). A STAC Collection is created from a [json document](../deploy/sample-data/collection_naip_test.json) that is uploaded to the appropriate container in the Storage Account.
+1. First step in the process is the creation of the
+[STAC collection](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md).
+A STAC Collection is created from a [json document](../deploy/sample-data/collection_naip_test.json)
+that is uploaded to the appropriate container in the Storage Account.
 
     ```bash
-    curl -s https://raw.githubusercontent.com/Azure/Azure-Orbital-STAC/main/deploy/sample-data/collection_naip_test.json | azcopy copy "https://<data-storage-account>.blob.core.windows.net/staccollection/collection_naip_test.json?<SAS-token-for-data-storage-account>" --from-to PipeBlob
+    curl -s https://raw.githubusercontent.com/Azure/Azure-Orbital-STAC/main/deploy/sample-data/collection_naip_test.json | \
+    azcopy copy "https://<data-storage-account>.blob.core.windows.net/staccollection/collection_naip_test.json?<SAS-token-for-data-storage-account>" --from-to PipeBlob
     ```
 
 2. Generate the SAS token for getting the data from Planetary Computers.
@@ -18,7 +26,8 @@ The steps below walk you through the creation of STAC Collection and STAC Item. 
     TOKEN=$(curl -s https://planetarycomputer.microsoft.com/api/sas/v1/token/naip | jq -r .token)
     ```
 
-    Alternatively, clicking on the link <https://planetarycomputer.microsoft.com/api/sas/v1/token/naip> will give an output like the following:
+    Alternatively, clicking on the link <https://planetarycomputer.microsoft.com/api/sas/v1/token/naip>
+    will give an output like the following:
 
     ```json
     {
@@ -27,14 +36,18 @@ The steps below walk you through the creation of STAC Collection and STAC Item. 
     }
     ```
 
-    The `token` field is the SAS token. The `msft:expiry` field specifies the time (in UTC) this token expires, which is 45 mins from the time it was first generated. Set the variable `TOKEN` to the token value.
+    The `token` field is the SAS token. The `msft:expiry` field specifies the
+    time (in UTC) this token expires, which is 45 mins from the time it was
+    first generated. Set the variable `TOKEN` to the token value.
 
     ```bash
     TOKEN=<value from token field>
 
     We will use this token to download the sample data.
 
-3. Once the STAC collection is created, the next steps is to create the [STAC Items](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md). Addition of the STAC Item to a STAC Collection is two step process.
+3. Once the STAC collection is created, the next steps is to create the
+[STAC Items](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md).
+Addition of the STAC Item to a STAC Collection is two step process.
 
     a. Upload metadata
 

--- a/docs/deploying-infra.md
+++ b/docs/deploying-infra.md
@@ -2,14 +2,17 @@
 
 The script requires following input
 
-- `environmentCode` which serves as the prefix for infrastructure services names. Allows only alpha numeric(no special characters) and must be between 3 and 8 characters.
+- `environmentCode` which serves as the prefix for infrastructure services
+   names. Allows only alpha numeric(no special characters) and must be
+   between 3 and 8 characters.
 - `location` which suggests which azure region infrastructure is deployed in.
-- `jumpboxPassword` through which users will SSH into Azure VM. The supplied password must be between 6-72 characters long
-and must satisfy at least 3 out of 4 of the following:
-  - Lowercase characters
-  - Uppercase characters
-  - Numbers (0-9)
-  - Special characters (except Control characters)
+- `jumpboxPassword` through which users will SSH into Azure VM. The supplied
+   password must be between 6-72 characters long and must satisfy at least 3
+   out of 4 of the following:
+     - Lowercase characters
+     - Uppercase characters
+     - Numbers (0-9)
+     - Special characters (except Control characters)
 
 The deployment involves the following steps outlined below:
 
@@ -21,7 +24,9 @@ No | Step | Duration (approx.) | Required / Optional
 
 ## Deployment & Configurations
 
-STAC solution is supported on multiple Azure clouds. If you work across different regions or use [Azure Stack](https://learn.microsoft.com/azure-stack/user/?view=azs-2206), you may need to use more than one cloud.
+STAC solution is supported on multiple Azure clouds. If you work across
+different regions or use [Azure Stack](https://learn.microsoft.com/azure-stack/user/?view=azs-2206),
+you may need to use more than one cloud.
 
 To get the active cloud and a list of all the available clouds:
 
@@ -37,7 +42,8 @@ False       AzureChinaCloud    latest
 False       AzureUSGovernment  latest
 False       AzureGermanCloud   latest
 ```
-The currently active cloud has `True` in the `IsActive` column. Only one cloud can be active at any time.
+The currently active cloud has `True` in the `IsActive` column. Only one cloud
+can be active at any time.
 
 To switch to one of the national clouds Ex: AzureUSGovernment
 
@@ -51,26 +57,31 @@ Active subscription switched to <'subscription name' (subscription id)>.
 ```
 
 **NOTE**
-If your authentication for the activated cloud has expired, you need to re-authenticate before performing any other CLI tasks. If this is your first time switching to the new cloud, you also need to set the active subscription.
+If your authentication for the activated cloud has expired, you need to
+re-authenticate before performing any other CLI tasks. If this is your first
+time switching to the new cloud, you also need to set the active subscription.
 
-(Optional) Login to azure as shown below and set the correct subscription in which you want to provision the resources. 
+(Optional) Login to azure as shown below and set the correct subscription in
+which you want to provision the resources. 
 
 ```azurecli
 az login
 az account set -s <subscription_id>
 ```
 
-For end-to-end deployment, you can either choose to run the `setup.sh` script that will take care of deploying all the services, building the docker images and configuring the variables or run the scripts individually as shown below.
+For end-to-end deployment, you can either choose to run the `setup.sh` script
+that will take care of deploying all the services, building the docker images
+and configuring the variables or run the scripts individually as shown below.
 
 Note: For Sovereign Clouds, 
 
-* set `APIM_PLATFORM_VERSION` to 'stv1' as 'stv2' is not supported. 
-* set `POSTGRES_PRIVATE_ENDPOINT_DISABLED` to true as Private EndPoint for PostgreSQL are not supported.
+* set `POSTGRES_PRIVATE_ENDPOINT_DISABLED` to true as Private EndPoint for
+  PostgreSQL are not supported.
 
-You can make the above changes by settings the environment variables using the commands below.
+You can make the above changes by settings the environment variables using the
+commands below.
 
 ```bash
-export APIM_PLATFORM_VERSION=stv1
 export POSTGRES_PRIVATE_ENDPOINT_DISABLED=true
 ```
 
@@ -107,7 +118,9 @@ OR
 
 2. Building Docker images
 
-   In this step, Docker images such as stac-event-consumer, generate-stac-json, stac-collection, and stac-fastapi will be built and deployed to ACR (Azure Container Registry).
+   In this step, Docker images such as stac-event-consumer, generate-stac-json,
+   stac-collection, and stac-fastapi will be built and deployed to ACR (Azure
+   Container Registry).
 
    ```bash
    ./deploy/scripts/build.sh <environmentCode>
@@ -115,7 +128,8 @@ OR
 
 3. Configuring and Deploying container applications
 
-   This step collects the required configuration variables from the infrastructure, and passes them to kubectl deployment specification.
+   This step collects the required configuration variables from the
+   infrastructure, and passes them to kubectl deployment specification.
 
    ```bash
    ./deploy/scripts/configure.sh <environmentCode>
@@ -123,8 +137,24 @@ OR
 
 ## Cleanup Script
 
-   Run the below script to clean up the Azure resources provisioned as part of the deployment. The script uses `environmentCode` to identify and remove the services.
+   Run the below script to clean up the Azure resources provisioned as part of
+   the deployment. The script uses `environmentCode` to identify and remove the
+   services.
 
    ```bash
    ./deploy/scripts/cleanup.sh <environmentCode>
    ```
+
+## Securing STAC APIs
+
+The deployment leaves the STAC API and blob proxy (to allow assets to be
+accessed) open by default. If you wish to protect the APIs so that you must
+authenticate to access them, you can do so by running:
+
+```bash
+./deploy/scripts/secure-stac-endpoints.sh <environmentCode>
+```
+
+This will deploy oauth2-proxy and require that you authenticate with Azure
+Active Directory (in the same tenant as the STAC deployment) in order to access
+resources.

--- a/docs/using-bastion-for-ssh.md
+++ b/docs/using-bastion-for-ssh.md
@@ -1,19 +1,31 @@
 # Using Bastion for SSH to Jumpbox
 
-This deployment includes a Jumpbox (Azure Virtual Machine) that will serve as the secure way to interact with the workload. The intend of this jumpbox is to provide a way to perform activities required for the workload:
+This deployment includes a Jumpbox (Azure Virtual Machine) that will serve as
+the secure way to interact with the workload. The intend of this jumpbox is to
+provide a way to perform activities required for the workload:
 
 - Copying data from and to Storage Accounts inside private subnets
 - Copying data from and to Storage Accounts from public subnets
 - Access secrets from Key Vault in private subnets
 
-If you have an existing Virtual Network with an existing Jumpbox or an On-premise network connected via S2S VPN or Express route, you may use any device connected to those network to perform the activities listed above.
+If you have an existing Virtual Network with an existing Jumpbox or an
+On-premise network connected via S2S VPN or Express route, you may use any
+device connected to those network to perform the activities listed above.
 
 Follow the steps below to SSH into the Jumpbox using Bastion:
 
-1. In the Azure Portal, go to the virtual machine that you want to connect to. On the **Overview** page, select **Connect**, then select **Bastion** from the dropdown to open the Bastion connection page. You can also select **Bastion** from the left pane.
+1. In the Azure Portal, go to the virtual machine that you want to connect to.
+On the **Overview** page, select **Connect**, then select **Bastion** from the
+dropdown to open the Bastion connection page. You can also select **Bastion**
+from the left pane.
 
-2. On the Bastion connection page, click the **Connection Settings** arrow to expand all available settings.
+2. On the Bastion connection page, click the **Connection Settings** arrow to
+expand all available settings.
 
-3. Authenticate and connect using Password based Authentication. You can use the [Password - Azure Key Vault](https://docs.microsoft.com/en-us/azure/bastion/bastion-connect-vm-ssh-linux#password---azure-key-vault) approach to directly use your jumpbox password store in Key Vault as Secret.
+3. Authenticate and connect using Password based Authentication. You can use
+the [Password - Azure Key Vault](https://docs.microsoft.com/en-us/azure/bastion/bastion-connect-vm-ssh-linux#password---azure-key-vault)
+approach to directly use your jumpbox password store in Key Vault as Secret.
 
-**Note:** Your Jumpbox SSH password is password in the Key Vault deployed to the `<environment-code>-data-rg` resource group under the name `<jumpbox-name>-Password` secret.
+**Note:** Your Jumpbox SSH password is password in the Key Vault deployed to
+the `<environment-code>-data-rg` resource group under the name
+`<jumpbox-name>-Password` secret.


### PR DESCRIPTION
This PR removes API management and replaces it with the nginx Kubernetes ingress controller. It also adds stac-browser, and optionally secures the APIs using oauth2-proxy.

This PR contains all of the changes in #37, and therefore should not be merged until PR #37 is merged and this branch has been rebased.