### PR TITLE
Fix uami timing and deploymentscript re-run issue

### DIFF
--- a/deploy/bicep/groups/processing.bicep
+++ b/deploy/bicep/groups/processing.bicep
@@ -92,6 +92,22 @@ module aksManagedIdentity '../modules/managed.identity.user.bicep' = {
   }
 }
 
+resource waitSection 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  kind: 'AzurePowerShell'
+  name: 'WaitSection'
+  location: location
+  properties: {
+    azPowerShellVersion: '3.0'
+    scriptContent: 'start-sleep -Seconds 300'
+    cleanupPreference: 'Always'
+    retentionInterval: 'PT1H'
+  }
+  dependsOn: [
+    aksManagedIdentity
+  ]
+}
+
+
 module akvPolicyForMI '../modules/akv.policy.bicep' = {
   name: '${namingPrefix}-aks-policy-for-mi'
   scope: resourceGroup(keyVaultResourceGroupName)
@@ -104,6 +120,9 @@ module akvPolicyForMI '../modules/akv.policy.bicep' = {
       'List'
     ]
   }
+  dependsOn: [
+    waitSection
+  ]
 }
 
 module aksCluster '../modules/aks-cluster.bicep' =  {

--- a/deploy/scripts/install.sh
+++ b/deploy/scripts/install.sh
@@ -82,3 +82,5 @@ DEPLOYMENT_SCRIPT="az deployment sub create -o none -l $LOCATION -n $DEPLOYMENT_
     owner_aad_object_id=$USER_OBJ_ID $DNS_ARG"
 
 $DEPLOYMENT_SCRIPT
+
+az deployment-scripts list -g "${ENV_CODE}-vnet-rg" --query "[].name" -o tsv | xargs -otl az deployment-scripts delete -g "${ENV_CODE}-vnet-rg" $_ --yes --name


### PR DESCRIPTION
UAMI needs a few minutes to propagate through Azure AD and may cause timing issue in some tenants. So, a pause of 5 minutes is added after its creation.

The bicep template is not idempotent because the vnet and its subnets cannot be redeployed using bicep template. So, a solution was put in place earlier where deploymentScript would check the existence of the Vnet and conditionally deploy the vnet and its subnets. However, the deploymentScript does not re-run until the contents of the script changes. 

So when it first runs, its output says the vnet does not exists. Subsequent deployments also use the same output since the deploymentScript is not re-run as the content of the script did not change.

As a fix, I'm deleting the deploymentScript at the end of each run.